### PR TITLE
add halt and reboot to make clean

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -35,7 +35,7 @@ endif
 
 clean:
 	rm -f *.o *.d
-	rm -f dinit dinitctl shutdown
+	rm -f dinit dinitctl shutdown halt reboot
 	$(MAKE) -C tests clean
 
 -include $(objects:.o=.d)


### PR DESCRIPTION
`make clean` doesn't properly clean all build artefacts