### PR TITLE
Adding root check on default control socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,10 +311,12 @@ dependents are configured).
 If stopping a service would also require a dependent service to stop, a warning
 will be issued and the `--force` option will be required.
 
-Use the "-s" switch to talk the "system" instance of Dinit, rather than a
-personal instance, e.g:
+Use the "-u" switch to talk the "user" instance of Dinit, rather than the system
+instance, e.g:
 
-    dinitctl -s start mysql   # start system mysql service
+    dinitctl -u start mysql   # start user mysql service
+
+The -u flag is implicitely set when calling dinitctl as a regular user, not when root.
 
 For complete details on the command line, use:
 
@@ -324,9 +326,9 @@ You can "pin" a service in either the stopped or started state, which prevents
 it from changing state either due to a dependency/dependent or a direct
 command:
 
-    dinitctl -s start --pin mysql  # start mysql service, pin it as "started"
-    dinitctl -s stop mysql  # issues stop, but doesn't take effect due to pin
-    dinitctl -s unpin mysql # release pin; service will now stop
+    dinitctl start --pin mysql  # start mysql service, pin it as "started"
+    dinitctl stop mysql  # issues stop, but doesn't take effect due to pin
+    dinitctl unpin mysql # release pin; service will now stop
 
 You can pin a service in the stopped state in order to make sure it doesn't
 get started accidentally (either via a dependency or directly). You can also
@@ -336,7 +338,7 @@ to restart automatically).
 
 Finally, you can list the state of all loaded services:
 
-    dinitctl -s list
+    dinitctl list
 
 This may result in something like the following:
 

--- a/doc/manpages/dinitctl.8.m4
+++ b/doc/manpages/dinitctl.8.m4
@@ -55,8 +55,8 @@ service status.
 \fB\-\-help\fR
 display this help and exit
 .TP
-\fB\-s\fR, \fB\-\-system\fR
-Control the system init process. The default is to control the user process. This option selects
+\fB\-u\fR, \fB\-\-user\fR
+Control the user init process. The default is to control the system process. This option selects
 the path to the control socket used to communicate with the \fBdinit\fR daemon process.
 .TP
 \fB\-\-socket\-path\fR \fIsocket-path\fR, \fB\-p\fR \fIsocket-path\fR

--- a/src/dinitctl.cc
+++ b/src/dinitctl.cc
@@ -91,7 +91,7 @@ int main(int argc, char **argv)
     const char * control_socket_path = nullptr;
     
     bool verbose = true;
-    bool sys_dinit = false;  // communicate with system daemon
+    bool user_dinit = (getuid() != 0);  // communicate with user daemon
     bool wait_for_service = true;
     bool do_pin = false;
     bool do_force = false;
@@ -110,8 +110,8 @@ int main(int argc, char **argv)
             else if (strcmp(argv[i], "--quiet") == 0) {
                 verbose = false;
             }
-            else if (strcmp(argv[i], "--system") == 0 || strcmp(argv[i], "-s") == 0) {
-                sys_dinit = true;
+            else if (strcmp(argv[i], "--user") == 0 || strcmp(argv[i], "-u") == 0) {
+                user_dinit = true;
             }
             else if (strcmp(argv[i], "--pin") == 0) {
                 do_pin = true;
@@ -274,7 +274,7 @@ int main(int argc, char **argv)
           "\n"
           "General options:\n"
           "  --help           : show this help\n"
-          "  -s, --system     : control system daemon instead of user daemon\n"
+          "  -u, --user       : control user daemon instead of system daemon\n"
           "  --quiet          : suppress output (except errors)\n"
           "  --socket-path <path>, -p <path>\n"
           "                   : specify socket for communication with daemon\n"
@@ -294,7 +294,7 @@ int main(int argc, char **argv)
     }
     else {
         control_socket_path = SYSCONTROLSOCKET; // default to system
-        if (! sys_dinit) {
+        if (user_dinit) {
             char * userhome = getenv("HOME");
             if (userhome == nullptr) {
                 struct passwd * pwuid_p = getpwuid(getuid());


### PR DESCRIPTION
This removes the need to use --system when dinitctl runs as root.