### PR TITLE
Fix makefile.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -33,7 +33,7 @@ includes/mconfig.h: mconfig-gen
 mconfig-gen: mconfig-gen.cc ../mconfig
 	$(HOSTCXX) $(HOSTCXXOPTS) -o mconfig-gen mconfig-gen.cc $(HOSTLDFLAGS)
 
-$(dinit_objects): includes/mconfig.h
+$(objects): includes/mconfig.h
 
 dinit: $(dinit_objects)
 	$(CXX) -o dinit $(dinit_objects) $(LDFLAGS)


### PR DESCRIPTION
This fixes the following error while compiling:
```
make -C src all
make[1]: Entering directory '/builddir/dinit-0.7.0/src'
g++  -o mconfig-gen mconfig-gen.cc -Wl,-z,relro -Wl,-z,now -Wl,--as-needed    
g++ -D_GLIBCXX_USE_CXX11_ABI=1 -std=c++11 -Os -Wall -fno-rtti -fno-plt -flto -MMD -MP -Iincludes -Idasynq -c dinitctl.cc -o dinitctl.o
dinitctl.cc:26:10: fatal error: mconfig.h: No such file or directory
   26 | #include "mconfig.h"
      |          ^~~~~~~~~~~
compilation terminated.
make[1]: *** [Makefile:48: dinitctl.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/builddir/dinit-0.7.0/src'
make: *** [Makefile:4: all] Error 2
```

Let me know if this is {in}correct since I have never formally learned how makefiles work.