### PR TITLE
use symlinks instead of hardlinks for command aliases, provide "poweroff" alias

### DIFF
--- a/doc/manpages/Makefile
+++ b/doc/manpages/Makefile
@@ -12,8 +12,8 @@ install: generate
 	install -m644 dinit-service.5 "$(DESTDIR)$(MANDIR)/man5"
 ifeq ($(BUILD_SHUTDOWN),yes)
 	install -m644 shutdown.8 "$(DESTDIR)$(MANDIR)/man8"
-	ln -f "$(DESTDIR)$(MANDIR)/man8/shutdown.8" "$(DESTDIR)$(MANDIR)/man8/halt.8" 
-	ln -f "$(DESTDIR)$(MANDIR)/man8/shutdown.8" "$(DESTDIR)$(MANDIR)/man8/reboot.8" 
+	ln -sf "shutdown.8" "$(DESTDIR)$(MANDIR)/man8/halt.8"
+	ln -sf "shutdown.8" "$(DESTDIR)$(MANDIR)/man8/reboot.8"
 endif
 
 clean:

--- a/doc/manpages/Makefile
+++ b/doc/manpages/Makefile
@@ -14,6 +14,7 @@ ifeq ($(BUILD_SHUTDOWN),yes)
 	install -m644 shutdown.8 "$(DESTDIR)$(MANDIR)/man8"
 	ln -sf "shutdown.8" "$(DESTDIR)$(MANDIR)/man8/halt.8"
 	ln -sf "shutdown.8" "$(DESTDIR)$(MANDIR)/man8/reboot.8"
+	ln -sf "shutdown.8" "$(DESTDIR)$(MANDIR)/man8/poweroff.8"
 endif
 
 clean:

--- a/doc/manpages/shutdown.8.m4
+++ b/doc/manpages/shutdown.8.m4
@@ -1,7 +1,7 @@
 changequote(`@@@',`$$$')dnl
 @@@.TH SHUTDOWN "8" "$$$MONTH YEAR@@@" "Dinit $$$VERSION@@@" "Dinit \- service management system"
 .SH NAME
-shutdown, halt, reboot \- system shutdown 
+shutdown, halt, poweroff, reboot \- system shutdown 
 .\"
 .SH SYNOPSIS
 .\"
@@ -11,6 +11,8 @@ shutdown, halt, reboot \- system shutdown
 .br
 \fBhalt\fR [\fIoptions...\fR]
 .br
+\fBpoweroff\fR [\fIoptions...\fR]
+.br
 \fBreboot\fR [\fIoptions...\fR]
 .\"
 .SH DESCRIPTION
@@ -18,13 +20,14 @@ shutdown, halt, reboot \- system shutdown
 This manual page is for the shutdown utility included with the \fBDinit\fR
 service manager package. See \fBdinit\fR(8).
 
-The shutdown, reboot and halt commands can be used to instruct the service
-manager daemon to perform a service rollback and then to shutdown the
+The shutdown, reboot, poweroff and halt commands can be used to instruct the
+service manager daemon to perform a service rollback and then to shutdown the
 system. They can also perform shutdown directly, without service rollback.
 
-Note that for consistency with other packages a "halt" alias is provided,
-however it has no special significance. The default action is to power down
-the system if called as either "shutdown" or "halt".
+Note that for consistency with other packages "halt" and "poweroff" aliases
+are provided, however they have no special significance. The default action
+is to power down the system if called as either "shutdown", "halt", or
+"poweroff".
 .\"
 .SH OPTIONS
 .TP

--- a/src/Makefile
+++ b/src/Makefile
@@ -60,6 +60,7 @@ install: all
 ifeq ($(BUILD_SHUTDOWN),yes)
 	ln -sf $(SHUTDOWN) $(DESTDIR)$(SBINDIR)/$(SHUTDOWNPREFIX)halt
 	ln -sf $(SHUTDOWN) $(DESTDIR)$(SBINDIR)/$(SHUTDOWNPREFIX)reboot
+	ln -sf $(SHUTDOWN) $(DESTDIR)$(SBINDIR)/$(SHUTDOWNPREFIX)poweroff
 endif
 
 clean:

--- a/src/Makefile
+++ b/src/Makefile
@@ -58,8 +58,8 @@ install: all
 	install -d $(DESTDIR)$(SBINDIR)
 	install $(STRIPOPTS) dinit dinitctl dinitcheck $(SHUTDOWN) $(DESTDIR)$(SBINDIR)
 ifeq ($(BUILD_SHUTDOWN),yes)
-	ln -f $(DESTDIR)$(SBINDIR)/$(SHUTDOWN) $(DESTDIR)$(SBINDIR)/$(SHUTDOWNPREFIX)halt
-	ln -f $(DESTDIR)$(SBINDIR)/$(SHUTDOWN) $(DESTDIR)$(SBINDIR)/$(SHUTDOWNPREFIX)reboot
+	ln -sf $(SHUTDOWN) $(DESTDIR)$(SBINDIR)/$(SHUTDOWNPREFIX)halt
+	ln -sf $(SHUTDOWN) $(DESTDIR)$(SBINDIR)/$(SHUTDOWNPREFIX)reboot
 endif
 
 clean:


### PR DESCRIPTION
Symlinks are more obvious/easier to track than hardlinks and as far as I can tell there is no disadvantage to using them.

Additionally, provide a "poweroff" command alias. This is to improve compatibility with e.g. `elogind` which internally calls it when you try to shut down the system via `loginctl`.