### PR TITLE
Also pass CXXOPTS when linking

### DIFF
--- a/configs/mconfig.Darwin
+++ b/configs/mconfig.Darwin
@@ -11,7 +11,7 @@ SYSCONTROLSOCKET=/var/run/dinitctl
 # Cannot use -fno-rtti: apparently prevents exception handling from working properly.
 CXX=g++
 CXXOPTS=-std=c++11 -Os -Wall -flto
-LDFLAGS=-flto
+LDFLAGS=
 BUILD_SHUTDOWN=no
 SANITIZEOPTS=-fsanitize=address,undefined
 

--- a/configs/mconfig.Linux
+++ b/configs/mconfig.Linux
@@ -16,7 +16,7 @@ SYSCONTROLSOCKET=/run/dinitctl
 # the new ABI. See BUILD.txt file for more information.
 CXX=g++
 CXXOPTS=-D_GLIBCXX_USE_CXX11_ABI=1 -std=c++11 -Os -Wall -fno-rtti -fno-plt -flto
-LDFLAGS=-flto -Os
+LDFLAGS=
 BUILD_SHUTDOWN=yes
 SANITIZEOPTS=-fsanitize=address,undefined
 

--- a/configs/mconfig.Linux.sh
+++ b/configs/mconfig.Linux.sh
@@ -59,11 +59,6 @@ HAS_LTO=$?
 test_compiler_arg "$compiler" -fno-rtti
 test_compiler_arg "$compiler" -fno-plt
 BUILD_OPTS="-D_GLIBCXX_USE_CXX11_ABI=1 -std=c++11 -Os -Wall $supported_opts"
-if test $HAS_LTO = 0; then
-  LD_OPTS="-flto -Os"
-else
-  LD_OPTS=""
-fi
 
 echo "Using build options     : $supported_opts"
 
@@ -84,7 +79,7 @@ GENERAL_BUILD_SETTINGS=$(
   echo "# the new ABI. See BUILD.txt file for more information."
   echo "CXX=$compiler"
   echo "CXXOPTS=$BUILD_OPTS"
-  echo "LDFLAGS=$LD_OPTS"
+  echo "LDFLAGS="
   echo "BUILD_SHUTDOWN=yes"
   echo "SANITIZEOPTS=$SANITIZE_OPTS"
   echo ""

--- a/src/Makefile
+++ b/src/Makefile
@@ -31,16 +31,16 @@ all: dinit dinitctl dinitcheck $(SHUTDOWN)
 $(objects): ../build/includes/mconfig.h
 
 dinit: $(dinit_objects)
-	$(CXX) -o dinit $(dinit_objects) $(LDFLAGS)
+	$(CXX) -o dinit $(dinit_objects) $(CXXOPTS) $(LDFLAGS)
 
 dinitctl: dinitctl.o
-	$(CXX) -o dinitctl dinitctl.o $(LDFLAGS)
+	$(CXX) -o dinitctl dinitctl.o $(CXXOPTS) $(LDFLAGS)
 
 dinitcheck: dinitcheck.o options-processing.o
-	$(CXX) -o dinitcheck dinitcheck.o options-processing.o $(LDFLAGS)
+	$(CXX) -o dinitcheck dinitcheck.o options-processing.o $(CXXOPTS) $(LDFLAGS)
 
 $(SHUTDOWNPREFIX)shutdown: shutdown.o
-	$(CXX) -o $(SHUTDOWNPREFIX)shutdown shutdown.o $(LDFLAGS)
+	$(CXX) -o $(SHUTDOWNPREFIX)shutdown shutdown.o $(CXXOPTS) $(LDFLAGS)
 
 $(objects): %.o: %.cc
 	$(CXX) $(CXXOPTS) -MMD -MP -Iincludes -I../dasynq/include -I../build/includes -c $< -o $@

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -22,13 +22,13 @@ prepare-incdir:
 	cd includes; ln -f ../test-includes/*.h .
 
 tests: $(parent_objs) tests.o test-dinit.o test-bpsys.o test-run-child-proc.o
-	$(CXX) $(SANITIZEOPTS) -o tests $(parent_objs) tests.o test-dinit.o test-bpsys.o test-run-child-proc.o $(LDFLAGS)
+	$(CXX) $(SANITIZEOPTS) -o tests $(parent_objs) tests.o test-dinit.o test-bpsys.o test-run-child-proc.o $(CXXOPTS) $(LDFLAGS)
 
 proctests: $(parent_objs) proctests.o test-dinit.o test-bpsys.o test-run-child-proc.o
-	$(CXX) $(SANITIZEOPTS) -o proctests $(parent_objs) proctests.o test-dinit.o test-bpsys.o test-run-child-proc.o $(LDFLAGS)
+	$(CXX) $(SANITIZEOPTS) -o proctests $(parent_objs) proctests.o test-dinit.o test-bpsys.o test-run-child-proc.o $(CXXOPTS) $(LDFLAGS)
 	
 loadtests: $(parent_objs) loadtests.o test-dinit.o test-bpsys.o test-run-child-proc.o
-	$(CXX) $(SANITIZEOPTS) -o loadtests $(parent_objs) loadtests.o test-dinit.o test-bpsys.o test-run-child-proc.o $(LDFLAGS)
+	$(CXX) $(SANITIZEOPTS) -o loadtests $(parent_objs) loadtests.o test-dinit.o test-bpsys.o test-run-child-proc.o $(CXXOPTS) $(LDFLAGS)
 
 $(objects): %.o: %.cc
 	$(CXX) $(CXXOPTS) $(SANITIZEOPTS) -MMD -MP -Iincludes -I../../dasynq/include -I../../build/includes -c $< -o $@

--- a/src/tests/cptests/Makefile
+++ b/src/tests/cptests/Makefile
@@ -20,7 +20,7 @@ prepare-incdir:
 	cd includes; ln -f ../../test-includes/baseproc-sys.h .
 
 cptests: cptests.o $(parent_objs) $(parent_test_objs)
-	$(CXX) $(SANITIZEOPTS) -o cptests cptests.o $(parent_test_objects) $(parent_objs) $(LDFLAGS)
+	$(CXX) $(SANITIZEOPTS) -o cptests cptests.o $(parent_test_objects) $(parent_objs) $(CXXOPTS) $(LDFLAGS)
 
 $(objects): %.o: %.cc
 	$(CXX) $(CXXOPTS) $(SANITIZEOPTS) -MMD -MP -Iincludes -I../../../dasynq/include -I../../../build/includes -c $< -o $@


### PR DESCRIPTION
It is common convention that compiler flags are passed during linkage, providing increased robustness/convenience when e.g. cross-compiling or in some cases of LTO builds.