### PR TITLE
command to set a variable in activation environment

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,5 +1,6 @@
 Dinit is primarily written by Davin McCall.
 
 The following people have contributed:
+ * Daniel Kolesa - Code, testing, documentation.
  * Edd Barrett - Testing, documentation.
  * Fabien Poussin - Code, services, documentation.

--- a/doc/manpages/dinitctl.8.m4
+++ b/doc/manpages/dinitctl.8.m4
@@ -46,6 +46,9 @@ dinitctl \- control services supervised by Dinit
 .br
 .B dinitctl
 [\fIoptions\fR] \fBdisable\fR [\fB\-\-from\fR \fIfrom-service\fR] \fIto-service\fR
+.br
+.B dinitctl
+[\fIoptions\fR] \fBsetenv\fR [\fIname\fR[=\fIvalue\fR] \fI...\fR]
 .\"
 .SH DESCRIPTION
 .\"
@@ -216,6 +219,12 @@ Permanently disable a \fBwaits-for\fR dependency between two services. This is t
 Note that the \fBdisable\fR command affects only the dependency specified (or implied). It has no
 other effect, and a service that is "disabled" may still be started if it is a dependency of
 another started service.
+.TP
+\fBsetenv\fR
+Export one or more variables into the activation environment. The value can be provided on the command line
+or retrieved from the environment \fBdinitctl\fR is called in. Any subsequently started or restarted
+service will have these environment variables available. This is particularly useful for user services
+that need access to session information.
 .\"
 .SH SERVICE OPERATION
 .\"

--- a/src/igr-tests/environ/run-test.sh
+++ b/src/igr-tests/environ/run-test.sh
@@ -10,9 +10,12 @@ rm -f ./env-record
         -e environment2 \
 	checkenv
 
+../../dinit -d sd -u -p socket -q \
+	setenv1
+
 STATUS=FAIL
 if [ -e env-record ]; then
-   if [ "$(cat env-record)" = "$(echo hello; echo goodbye)" ]; then
+   if [ "$(cat env-record)" = "$(echo hello; echo goodbye; echo 3; echo 2; echo 1)" ]; then
        STATUS=PASS
    fi
 fi

--- a/src/igr-tests/environ/sd/setenv1
+++ b/src/igr-tests/environ/sd/setenv1
@@ -1,0 +1,3 @@
+type = process
+command = ./setenv.sh setenv1
+depends-on = setenv2

--- a/src/igr-tests/environ/sd/setenv2
+++ b/src/igr-tests/environ/sd/setenv2
@@ -1,0 +1,3 @@
+type = scripted
+command = ./setenv.sh setenv2
+depends-on = setenv3

--- a/src/igr-tests/environ/sd/setenv3
+++ b/src/igr-tests/environ/sd/setenv3
@@ -1,0 +1,2 @@
+type = scripted
+command = ./setenv.sh setenv3

--- a/src/igr-tests/environ/setenv.sh
+++ b/src/igr-tests/environ/setenv.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+case "$1" in
+    setenv1)
+        if [ "$FOO" = "foo" -a "$BAR" = "bar" -a "$BAZ" = "baz" ]; then
+            echo 1 >> ./env-record
+        fi
+        ;;
+    setenv2)
+        if [ "$FOO" = "foo" ]; then
+            echo 2 >> ./env-record
+            export BAR=bar
+            dinitctl -p socket setenv BAR BAZ=baz
+        fi
+        ;;
+    setenv3)
+        dinitctl -p socket setenv FOO=foo
+        echo 3 >> ./env-record
+        ;;
+    *) ;;
+esac

--- a/src/includes/control-cmds.h
+++ b/src/includes/control-cmds.h
@@ -45,6 +45,9 @@ constexpr static int DINIT_CP_QUERYSERVICENAME = 15;
 // Reload a service:
 constexpr static int DINIT_CP_RELOADSERVICE = 16;
 
+// Export a set of environment variables into activation environment:
+constexpr static int DINIT_CP_SETENV = 17;
+
 // Replies:
 
 // Reply: ACK/NAK to request

--- a/src/includes/control.h
+++ b/src/includes/control.h
@@ -152,6 +152,9 @@ class control_conn_t : private service_listener
     // Process a QUERYSERVICENAME packet.
     bool process_query_name();
 
+    // Process a SETENV packet.
+    bool process_setenv();
+
     // List all loaded services and their state.
     bool list_services();
 


### PR DESCRIPTION
This is a pretty rough draft, mostly to get comments right now.

It adds a new `setenv` command to `dinitctl`. The command can take any number of variables, either as variable names alone (in which case the value is retrieved from the environment `dinitctl` is called in) or in the format `FOO=bar` (which encodes the value).

Limitations:

- length of the name + value + `=` is limited to 1024 minus protocol overhead characters (do we want to bother with a chunked protocol that would let one pass longer vars? i'm leaning towards not, as it seems to be of limited use and likely a sign of doing something terribly wrong)

Fixes https://github.com/davmac314/dinit/issues/43