### PR TITLE
some dinitctl socket management enhancements

### DIFF
--- a/doc/manpages/dinit.8.m4
+++ b/doc/manpages/dinit.8.m4
@@ -54,7 +54,8 @@ default is \fI/etc/dinit/environment\fR; see \fBFILES\fR.
 Specifies \fIpath\fP as the path to the control socket used to listen for
 commands from the \fBdinitctl\fR program. The default for the system service
 manager is usually \fI/dev/dinitctl\fR (but can be configured at build time).
-For a user service manager the default is \fI$HOME/.dinitctl\fR.
+For a user service manager the default is either \fI$XDG_RUNTIME_DIR/dinitctl\fR
+or \fI$HOME/.dinitctl\fR, depending on whether \fI$XDG_RUNTIME_DIR\fR is set.
 .TP
 \fB\-l\fR \fIpath\fP, \fB\-\-log\-file\fR \fIpath\fP
 Species \fIpath\fP as the path to the log file, to which Dinit will log status

--- a/doc/manpages/dinitctl.8.m4
+++ b/doc/manpages/dinitctl.8.m4
@@ -77,6 +77,8 @@ the default path to the control socket used to communicate with the \fBdinit\fR 
 .TP
 \fB\-\-socket\-path\fR \fIsocket-path\fR, \fB\-p\fR \fIsocket-path\fR
 Specify the path to the socket used for communicating with the service manager daemon.
+When not specified, the \fIDINIT_SOCKET_PATH\fR environment variable is read, otherwise
+Dinit's default values are used.
 .TP
 \fB\-\-quiet\fR
 Suppress status output, except for errors. 

--- a/src/dinit.cc
+++ b/src/dinit.cc
@@ -410,10 +410,16 @@ int dinit_main(int argc, char **argv)
     event_loop.init();
 
     if (!am_system_init && !control_socket_path_set) {
-        const char * userhome = service_dir_opt::get_user_home();
-        if (userhome != nullptr) {
-            control_socket_str = userhome;
-            control_socket_str += "/.dinitctl";
+        const char * rundir = getenv("XDG_RUNTIME_DIR");
+        const char * sockname = "dinitctl";
+        if (rundir == nullptr) {
+            rundir = service_dir_opt::get_user_home();
+            sockname = ".dinitctl";
+        }
+        if (rundir != nullptr) {
+            control_socket_str = rundir;
+            control_socket_str.push_back('/');
+            control_socket_str += sockname;
             control_socket_path = control_socket_str.c_str();
         }
     }

--- a/src/dinitctl.cc
+++ b/src/dinitctl.cc
@@ -337,21 +337,27 @@ int main(int argc, char **argv)
             control_socket_path = control_socket_str.c_str();
         }
         else if (user_dinit) {
-            char * userhome = getenv("HOME");
-            if (userhome == nullptr) {
-                struct passwd * pwuid_p = getpwuid(getuid());
-                if (pwuid_p != nullptr) {
-                    userhome = pwuid_p->pw_dir;
+            const char * rundir = getenv("XDG_RUNTIME_DIR");
+            const char * sockname = "dinitctl";
+            if (rundir == nullptr) {
+                sockname = ".dinitctl";
+                rundir = getenv("HOME");
+                if (rundir == nullptr) {
+                    struct passwd * pwuid_p = getpwuid(getuid());
+                    if (pwuid_p != nullptr) {
+                        rundir = pwuid_p->pw_dir;
+                    }
                 }
             }
 
-            if (userhome != nullptr) {
-                control_socket_str = userhome;
-                control_socket_str += "/.dinitctl";
+            if (rundir != nullptr) {
+                control_socket_str = rundir;
+                control_socket_str.push_back('/');
+                control_socket_str += sockname;
                 control_socket_path = control_socket_str.c_str();
             }
             else {
-                cerr << "dinitctl: cannot locate user home directory (set HOME, check /etc/passwd file, or "
+                cerr << "dinitctl: cannot locate user home directory (set XDG_RUNTIME_DIR, HOME, check /etc/passwd file, or "
                         "specify socket path via -p)" << endl;
                 return 1;
             }

--- a/src/dinitctl.cc
+++ b/src/dinitctl.cc
@@ -331,8 +331,12 @@ int main(int argc, char **argv)
         control_socket_path = control_socket_str.c_str();
     }
     else {
-        control_socket_path = SYSCONTROLSOCKET; // default to system
-        if (user_dinit) {
+        const char * sockpath = getenv("DINIT_SOCKET_PATH");
+        if (sockpath) {
+            control_socket_str = sockpath;
+            control_socket_path = control_socket_str.c_str();
+        }
+        else if (user_dinit) {
             char * userhome = getenv("HOME");
             if (userhome == nullptr) {
                 struct passwd * pwuid_p = getpwuid(getuid());
@@ -351,6 +355,9 @@ int main(int argc, char **argv)
                         "specify socket path via -p)" << endl;
                 return 1;
             }
+        }
+        else {
+            control_socket_path = SYSCONTROLSOCKET; // default to system
         }
     }
     

--- a/src/igr-tests/environ/checkenv.sh
+++ b/src/igr-tests/environ/checkenv.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
 
+if [ "$TEST_VAR_ONE" = "hello" ]; then
+    echo "$DINIT_SOCKET_PATH" >> ./env-record
+fi
+
 echo "$TEST_VAR_ONE" >> ./env-record

--- a/src/igr-tests/environ/run-test.sh
+++ b/src/igr-tests/environ/run-test.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+export DINIT_SOCKET_PATH="$(pwd)/socket"
+
 rm -f ./env-record
 
 ../../dinit -d sd -u -p socket -q \
@@ -15,7 +17,7 @@ rm -f ./env-record
 
 STATUS=FAIL
 if [ -e env-record ]; then
-   if [ "$(cat env-record)" = "$(echo hello; echo goodbye; echo 3; echo 2; echo 1)" ]; then
+   if [ "$(cat env-record)" = "$(echo $DINIT_SOCKET_PATH; echo hello; echo goodbye; echo 3; echo 2; echo 1)" ]; then
        STATUS=PASS
    fi
 fi

--- a/src/igr-tests/environ/setenv.sh
+++ b/src/igr-tests/environ/setenv.sh
@@ -10,11 +10,11 @@ case "$1" in
         if [ "$FOO" = "foo" ]; then
             echo 2 >> ./env-record
             export BAR=bar
-            ../../dinitctl -p socket setenv BAR BAZ=baz
+            ../../dinitctl setenv BAR BAZ=baz
         fi
         ;;
     setenv3)
-        ../../dinitctl -p socket setenv FOO=foo
+        ../../dinitctl setenv FOO=foo
         echo 3 >> ./env-record
         ;;
     *) ;;


### PR DESCRIPTION
This brings two ideas; they are implemented separately, and I am myself not entirely sure if they're good ideas, so I want to raise it here to get some feedback.

1) Both `dinitctl` and `dinit` now read the environment variable `DINIT_SOCKET_PATH` and use it preferentially to determine what the control socket path is. Additionally, `dinit` exports the socket's path into the environment under that name, canonicalized/made absolute. The idea is that when you call `dinitctl` within the service environment, you don't have to worry about passing the socket path (the service may not even know the socket path otherwise, since the user who launches the `--user` instance is in charge of that). However, I'm not sure if both `dinit` and `dinictl` should read the var. Maybe only `dinitctl` should, and `dinit` should only export it.
2) If `XDG_RUNTIME_DIR` is set, it's used instead of `HOME` for the socket location by default (and not hidden anymore). This puts the socket out of the way into a temporary run-time-only location. If not set, the previous behavior is followed.