### PR TITLE
Default to .config for user services directory

### DIFF
--- a/doc/manpages/dinit-service.5.m4
+++ b/doc/manpages/dinit-service.5.m4
@@ -6,7 +6,7 @@ Dinit service description files
 .SH SYNOPSIS
 .\"
 .ft CR
-/etc/dinit.d/\fIservice-name\fR, $HOME/dinit.d/\fIservice-name\fR
+/etc/dinit.d/\fIservice-name\fR, $HOME/.config/dinit.d/\fIservice-name\fR
 .ft
 .\"
 .SH DESCRIPTION
@@ -19,7 +19,7 @@ service description file is named after the service it represents, and is
 a plain-text file with simple key-value format. The description files are
 located in a service description directory; by default, the system process
 searches \fI/etc/dinit.d\fR, \fI/usr/local/lib/dinit.d\fR and
-\fI/lib/dinit.d\fR, while a user process searches \fI$HOME/dinit.d\fR.
+\fI/lib/dinit.d\fR, while a user process searches \fI$HOME/.config/dinit.d\fR.
 .LP
 All services have a \fItype\fR and a set of \fIdependencies\fR. These are discussed
 in the following subsections. The type, dependencies, and other attributes are

--- a/doc/manpages/dinit.8.m4
+++ b/doc/manpages/dinit.8.m4
@@ -32,7 +32,7 @@ certain signals). This is currently fully supported only on Linux. See
 Dinit reads service descriptions from files located in a service
 description directory, normally one of \fI/etc/dinit.d\fR,
 \fI/usr/local/lib/dinit.d\fR or \fI/lib/dinit.d\fR for the system instance
-or just \fI$HOME/dinit.d\fR when run as a user process. See \fBSERVICE
+or just \fI$HOME/.config/dinit.d\fR when run as a user process. See \fBSERVICE
 DESCRIPTION FILES\fR for details of the service description format.
 .\"
 .SH OPTIONS
@@ -42,7 +42,7 @@ Specifies \fIdir\fP as the directory containing service definition files, can
 be set multiple times. Default directories are not searched for services when
 this option is provided.
 
-If not specified, the default is \fI$HOME/dinit.d\fR or, for the
+If not specified, the default is \fI$HOME/.config/dinit.d\fR or, for the
 system service manager, each of \fI/etc/dinit.d\fR, \fI/usr/local/lib/dinit.d\fR,
 and \fI/lib/dinit.d\fR (searched in that order).
 .TP
@@ -111,7 +111,7 @@ subsequent service names.
 .\"
 Service description files specify the parameters of each service. They are
 named for the service they describe, and are found in \fI/etc/dinit.d\fR
-for a system instance or \fI$HOME/dinit.d\fR for a user instance.
+for a system instance or \fI$HOME/.config/dinit.d\fR for a user instance.
 
 Service description files are read by Dinit on an "as needed" basis. Once a
 service description has been read the configuration can be altered in limited

--- a/doc/manpages/dinitcheck.8.m4
+++ b/doc/manpages/dinitcheck.8.m4
@@ -35,7 +35,7 @@ Specifies \fIdir\fP as the directory containing service definition files, can
 be set multiple times. Default directories are not searched for services when
 this option is provided.
 
-If not specified, the default is \fI$HOME/dinit.d\fR or, for the
+If not specified, the default is \fI$HOME/.config/dinit.d\fR or, for the
 system service manager, each of \fI/etc/dinit.d/fR, \fI/usr/local/lib/dinit.d\fR,
 and \fI/lib/dinit.d\fR (searched in that order).
 .TP

--- a/src/options-processing.cc
+++ b/src/options-processing.cc
@@ -35,11 +35,11 @@ void service_dir_opt::build_paths(bool am_system_init)
             const char * user_home = get_user_home();
             if (user_home != nullptr) {
                 size_t user_home_len = strlen(user_home);
-                size_t dinit_d_len = strlen("/dinit.d");
+                size_t dinit_d_len = strlen("/.config/dinit.d");
                 size_t full_len = user_home_len + dinit_d_len + 1;
                 char *service_dir_w = new char[full_len];
                 std::memcpy(service_dir_w, user_home, user_home_len);
-                std::memcpy(service_dir_w + user_home_len, "/dinit.d", dinit_d_len);
+                std::memcpy(service_dir_w + user_home_len, "/.config/dinit.d", dinit_d_len);
                 service_dir_w[full_len - 1] = 0;
 
                 service_dir_paths.emplace_back(service_dir_w, /*dyn_allocd=*/true);


### PR DESCRIPTION
The /etc directory is a directory for system configuration files.
The .config directory in most Linux systems nowadays mirrors this.

Explicitly do not follow XDG_CONFIG_HOME as changing that is of questionable value and the XDG base directory spec is overly complicated and has various quirky parts. However, IME most users appreciate having config files in a separate location and .config is where a lot of software stores these nowadays, so being consistent with that should be a good thing.

One may consider the location being in a hidden directory a potential issue, I think it's not really a problem since in most cases one wants to have this kind of stuff out of the way (dealing with service files is something one typically does rarely in production) and in other cases it should not be an issue (documentation explicitly states the path, and e.g. systemd also puts user units in .config/systemd/user).