### PR TITLE
CI: Enable integration tests on all test suites

### DIFF
--- a/.github/workflows/alpine-latest-aarch64.yml
+++ b/.github/workflows/alpine-latest-aarch64.yml
@@ -5,12 +5,13 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
 
 jobs:
   Alpine-latest-aarch64_build:
 
     runs-on: ubuntu-latest
-      
+
     steps:
     - uses: actions/checkout@v3
     - uses: uraimo/run-on-arch-action@v2

--- a/.github/workflows/alpine-latest-aarch64.yml
+++ b/.github/workflows/alpine-latest-aarch64.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: uraimo/run-on-arch-action@v2
-      name: Getting depends & configure & build & unit tests
+      name: Getting depends & configure & build & unit tests & integration tests
       with:
         arch: aarch64
         distro: alpine_latest
@@ -31,3 +31,4 @@ jobs:
           file ./src/dinit
           export LSAN_OPTIONS=verbosity=1:log_threads=1
           make check
+          make check-igr

--- a/.github/workflows/alpine-latest-armv6.yml
+++ b/.github/workflows/alpine-latest-armv6.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: uraimo/run-on-arch-action@v2
-      name: Getting depends & configure & build & unit tests
+      name: Getting depends & configure & build & unit tests & integration tests
       with:
         arch: armv6
         distro: alpine_latest
@@ -31,3 +31,4 @@ jobs:
           file ./src/dinit
           export LSAN_OPTIONS=verbosity=1:log_threads=1
           make check
+          make check-igr

--- a/.github/workflows/alpine-latest-armv6.yml
+++ b/.github/workflows/alpine-latest-armv6.yml
@@ -5,12 +5,13 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
 
 jobs:
   Alpine-latest-armv6_build:
 
     runs-on: ubuntu-latest
-      
+
     steps:
     - uses: actions/checkout@v3
     - uses: uraimo/run-on-arch-action@v2

--- a/.github/workflows/alpine-latest-armv7.yml
+++ b/.github/workflows/alpine-latest-armv7.yml
@@ -5,12 +5,13 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
 
 jobs:
   Alpine-latest-armv7_build:
 
     runs-on: ubuntu-latest
-      
+
     steps:
     - uses: actions/checkout@v3
     - uses: uraimo/run-on-arch-action@v2

--- a/.github/workflows/alpine-latest-armv7.yml
+++ b/.github/workflows/alpine-latest-armv7.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: uraimo/run-on-arch-action@v2
-      name: Getting depends & configure & build & unit tests
+      name: Getting depends & configure & build & unit tests & integration tests
       with:
         arch: armv7
         distro: alpine_latest
@@ -31,3 +31,4 @@ jobs:
           file ./src/dinit
           export LSAN_OPTIONS=verbosity=1:log_threads=1
           make check
+          make check-igr

--- a/.github/workflows/debian-bullseye-amd64.yml
+++ b/.github/workflows/debian-bullseye-amd64.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
 
 jobs:
   Debian-bullseye-amd64_build:

--- a/.github/workflows/debian-bullseye-amd64.yml
+++ b/.github/workflows/debian-bullseye-amd64.yml
@@ -5,7 +5,6 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
-  workflow_dispatch:
 
 jobs:
   Debian-bullseye-amd64_build:
@@ -32,6 +31,5 @@ jobs:
       run: file ./src/dinit
     - name: Unit tests
       run: make check
-## Integration tests disabled due some bugs
-#    - name: Integration tests
-#      run: make check-igr
+    - name: Integration tests
+      run: make check-igr

--- a/.github/workflows/debian-bullseye-i386.yml
+++ b/.github/workflows/debian-bullseye-i386.yml
@@ -5,7 +5,6 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
-  workflow_dispatch:
 
 jobs:
   Debian-bullseye-i386_build:
@@ -34,6 +33,5 @@ jobs:
       run: file ./src/dinit
     - name: Unit tests
       run: make check
-## Integration tests disabled due some bugs
-#    - name: Integration tests
-#      run: make check-igr
+    - name: Integration tests
+      run: make check-igr

--- a/.github/workflows/debian-bullseye-i386.yml
+++ b/.github/workflows/debian-bullseye-i386.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
 
 jobs:
   Debian-bullseye-i386_build:


### PR DESCRIPTION
## ToDo
- [x] Fix: "integration tests fail on github action" #62 

`Signed-off-by: Mobin <mobin@mobintestserver.ir>`