### PR TITLE
don't mount devpts and shm again

### DIFF
--- a/doc/linux/services/filesystems.sh
+++ b/doc/linux/services/filesystems.sh
@@ -6,8 +6,6 @@ set -e
 if [ "$1" != "stop" ]; then
 
   echo "Mounting auxillary filesystems...."
-  mount -t tmpfs -o nodev,nosuid tmpfs /dev/shm
-  mount -t devpts -o gid=tty devpts /dev/pts
   swapon /swapfile
   mount -avt noproc,nonfs
 


### PR DESCRIPTION
devpts and shm are already being mounted in `early-filesystems.sh`