### PR TITLE
CI: Update `run-on-arch` from `v2` to `v2.2.0`

### DIFF
--- a/.github/workflows/alpine-latest-aarch64.yml
+++ b/.github/workflows/alpine-latest-aarch64.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: uraimo/run-on-arch-action@v2
+    - uses: uraimo/run-on-arch-action@v2.2.0
       name: Getting depends & configure & build & unit tests & integration tests
       with:
         arch: aarch64

--- a/.github/workflows/alpine-latest-armv6.yml
+++ b/.github/workflows/alpine-latest-armv6.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: uraimo/run-on-arch-action@v2
+    - uses: uraimo/run-on-arch-action@v2.2.0
       name: Getting depends & configure & build & unit tests & integration tests
       with:
         arch: armv6

--- a/.github/workflows/alpine-latest-armv7.yml
+++ b/.github/workflows/alpine-latest-armv7.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: uraimo/run-on-arch-action@v2
+    - uses: uraimo/run-on-arch-action@v2.2.0
       name: Getting depends & configure & build & unit tests & integration tests
       with:
         arch: armv7


### PR DESCRIPTION
 Hello.
 `run-on-arch` used to compile & test Dinit on arm(s) platform.

 This PR updates runs-on-arch to version 2.2.0. The most important feature of this additional version is `$github_env`, which will be useful in the future.

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`