### PR TITLE
Add support for "Loading any service with `dinit` on `system manager mode`"

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,4 +4,4 @@ The following people have contributed:
  * Daniel Kolesa - Code, testing, documentation.
  * Edd Barrett - Testing, documentation.
  * Fabien Poussin - Code, services, documentation.
- * Mobin Aydinfar - CI
+ * Mobin Aydinfar - Code, documentation, CI

--- a/doc/manpages/dinit.8.m4
+++ b/doc/manpages/dinit.8.m4
@@ -117,11 +117,16 @@ If none are specified, defaults to \fIboot\fR (which requires that a suitable se
 for the \fIboot\fR service exists).
 .sp
 \fBNote:\fR on Linux, if \fBdinit\fR is running as PID 1 and with UID 0, it will ignore
-service names provided on the command line, other than "single", unless they appear
+service names provided on the command line, other than "single", unless use \fB-t\fR, \fB--service\fR argument or they appear
 anywhere after the "\-o" or "\-m" options (or their long forms).
 This is to filter arguments that were intended for the kernel and not for \fBinit\fR.
 If running in a container, the "\-o" option should be used regardless and will inhibit this
 filtering for any subsequent service names.
+.TP
+\fB\-t\fR, \fB--service\fR \fIservice-name\fR
+Specifies the name of a service that should be started (along with its
+dependencies) and its work when \fBdinit\fR started as \fBinit\fR. you can use this argument(s) in kernel/bootloader command line (E.g: \fB-t tty1\fR).
+also possible to start several services by adding several \fB-t\fR, \fB--service\fR (E.g: \fB-t tty1 -t tty2\fR).
 .\"
 .SH SERVICE DESCRIPTION FILES
 .\"

--- a/src/dinit.cc
+++ b/src/dinit.cc
@@ -322,10 +322,10 @@ static int process_commandline_arg(char **argv, int argc, int &i, options &opts)
             }
         }
         #endif
-        else if (strcmp(argv[i], "--service") == 0) {
+        else if (strcmp(argv[i], "--service") == 0 || strcmp(argv[i], "-t") == 0) {
             if (++i < argc) {
                 services_to_start.push_back(argv[i]);
-            } 
+            }
             else {
                 cerr << "dinit: '--service' requires an argument\n";
                 return 1;
@@ -359,7 +359,8 @@ static int process_commandline_arg(char **argv, int argc, int &i, options &opts)
                     " --log-file <file>, -l <file> log to the specified file\n"
                     " --quiet, -q                  disable output to standard output\n"
                     " <service-name>               start service with name <service-name>\n"
-                    " --service <service-name>     start service with name <service-name>\n";
+                    " --service <service-name>, -t <service-name>\n" 
+                    "                              start service with name <service-name>\n";
             return -1;
         }
         else {

--- a/src/dinit.cc
+++ b/src/dinit.cc
@@ -86,7 +86,7 @@ bool external_log_open = false;
 int active_control_conns = 0;
 int socket_ready_fd = -1;
 bool specifie_service_loading = false; // true if use "--service" argument
-char specifie_service_path; // Its empty variable. if use "--service", service name saves in this variable
+char *specifie_service_path; // Its empty variable. if use "--service", service name saves in this variable
 
 // Control socket path. We maintain a string (control_socket_str) in case we need
 // to allocate storage, but control_socket_path is the authoritative value.
@@ -325,8 +325,14 @@ static int process_commandline_arg(char **argv, int argc, int &i, options &opts)
         }
         #endif
         else if (strcmp(argv[i], "--service") == 0) {
-            specifie_service_loading = true;
-            specifie_service_path = argv[i];
+            if (++i < argc) {
+                specifie_service_loading = true;
+                specifie_service_path = argv[i];
+            } 
+            else {
+                cerr << "dinit: '--service' requires an argument\n";
+                retrun 1;
+            }
         }
         else if (strcmp(argv[i], "--version") == 0) {
             printVersion();
@@ -393,7 +399,8 @@ static int process_commandline_arg(char **argv, int argc, int &i, options &opts)
 
         if (!opts.process_sys_args || strcmp(argv[i], "single") == 0) {
             services_to_start.push_back(argv[i]);
-        } else if (specifie_service_loading) {
+        } 
+        else if (specifie_service_loading) {
             services_to_start.push_back(specifie_service_path);
         }
 #else

--- a/src/dinit.cc
+++ b/src/dinit.cc
@@ -349,8 +349,7 @@ static int process_commandline_arg(char **argv, int argc, int &i, options &opts)
                     #endif
                     " --log-file <file>, -l <file> log to the specified file\n"
                     " --quiet, -q                  disable output to standard output\n"
-                    " --service <service-name>     start service with name <service-name>\n"
-                    " single                       start 'single' service";
+                    " <service-name> [...]         start service with name <service-name>\n";
             return -1;
         }
         else {

--- a/src/dinit.cc
+++ b/src/dinit.cc
@@ -331,7 +331,7 @@ static int process_commandline_arg(char **argv, int argc, int &i, options &opts)
             } 
             else {
                 cerr << "dinit: '--service' requires an argument\n";
-                retrun 1;
+                return 1;
             }
         }
         else if (strcmp(argv[i], "--version") == 0) {

--- a/src/dinit.cc
+++ b/src/dinit.cc
@@ -85,8 +85,6 @@ static bool control_socket_open = false;
 bool external_log_open = false;
 int active_control_conns = 0;
 int socket_ready_fd = -1;
-bool specifie_service_loading = false; // true if use "--service" argument
-char *specifie_service_path; // Its empty variable. if use "--service", service name saves in this variable
 
 // Control socket path. We maintain a string (control_socket_str) in case we need
 // to allocate storage, but control_socket_path is the authoritative value.
@@ -326,8 +324,7 @@ static int process_commandline_arg(char **argv, int argc, int &i, options &opts)
         #endif
         else if (strcmp(argv[i], "--service") == 0) {
             if (++i < argc) {
-                specifie_service_loading = true;
-                specifie_service_path = argv[i];
+                services_to_start.push_back(argv[i]);
             } 
             else {
                 cerr << "dinit: '--service' requires an argument\n";
@@ -361,6 +358,7 @@ static int process_commandline_arg(char **argv, int argc, int &i, options &opts)
                     #endif
                     " --log-file <file>, -l <file> log to the specified file\n"
                     " --quiet, -q                  disable output to standard output\n"
+                    " <service-name>               start service with name <service-name>\n"
                     " --service <service-name>     start service with name <service-name>\n";
             return -1;
         }
@@ -399,9 +397,6 @@ static int process_commandline_arg(char **argv, int argc, int &i, options &opts)
 
         if (!opts.process_sys_args || strcmp(argv[i], "single") == 0) {
             services_to_start.push_back(argv[i]);
-        } 
-        else if (specifie_service_loading) {
-            services_to_start.push_back(specifie_service_path);
         }
 #else
         services_to_start.push_back(argv[i]);

--- a/src/dinit.cc
+++ b/src/dinit.cc
@@ -327,7 +327,7 @@ static int process_commandline_arg(char **argv, int argc, int &i, options &opts)
                 services_to_start.push_back(argv[i]);
             }
             else {
-                cerr << "dinit: '--service' requires an argument\n";
+                cerr << "dinit: '--service' (-t) requires an argument\n";
                 return 1;
             }
         }

--- a/src/dinit.cc
+++ b/src/dinit.cc
@@ -85,6 +85,8 @@ static bool control_socket_open = false;
 bool external_log_open = false;
 int active_control_conns = 0;
 int socket_ready_fd = -1;
+bool specifie_service_loading = false; // true if use "--service" argument
+char specifie_service_path; // Its empty variable. if use "--service", service name saves in this variable
 
 // Control socket path. We maintain a string (control_socket_str) in case we need
 // to allocate storage, but control_socket_path is the authoritative value.
@@ -322,6 +324,10 @@ static int process_commandline_arg(char **argv, int argc, int &i, options &opts)
             }
         }
         #endif
+        else if (strcmp(argv[i], "--service") == 0) {
+            specifie_service_loading = true;
+            specifie_service_path = argv[i];
+        }
         else if (strcmp(argv[i], "--version") == 0) {
             printVersion();
             return -1;
@@ -349,7 +355,7 @@ static int process_commandline_arg(char **argv, int argc, int &i, options &opts)
                     #endif
                     " --log-file <file>, -l <file> log to the specified file\n"
                     " --quiet, -q                  disable output to standard output\n"
-                    " <service-name> [...]         start service with name <service-name>\n";
+                    " --service <service-name>     start service with name <service-name>\n";
             return -1;
         }
         else {
@@ -387,6 +393,8 @@ static int process_commandline_arg(char **argv, int argc, int &i, options &opts)
 
         if (!opts.process_sys_args || strcmp(argv[i], "single") == 0) {
             services_to_start.push_back(argv[i]);
+        } else if (specifie_service_loading) {
+            services_to_start.push_back(specifie_service_path);
         }
 #else
         services_to_start.push_back(argv[i]);

--- a/src/dinit.cc
+++ b/src/dinit.cc
@@ -349,7 +349,8 @@ static int process_commandline_arg(char **argv, int argc, int &i, options &opts)
                     #endif
                     " --log-file <file>, -l <file> log to the specified file\n"
                     " --quiet, -q                  disable output to standard output\n"
-                    " <service-name> [...]         start service with name <service-name>\n";
+                    " --service <service-name>     start service with name <service-name>\n"
+                    " single                       start 'single' service";
             return -1;
         }
         else {


### PR DESCRIPTION
Hi!
This issue is discussed in #69 (although we need to talk more about it now). This time, I decided to add Add support for "Loading any service with dinit on system manager mode" with my c++ knowledge.

Fix #69

## Goal
Add support for loading a service at boot time. its good for create `rescue` service and boot it if necessary also its good for have SystemD target-like services.

## ToDo
- [x] Fix: We can Load a service with `dinit` in `user mode` but `dinit` restricts this feature to `single` service when run in `system manager mode`.
- ~~Pay attention to issue #74 and use `string_ha` instead of `string` if necessary (I have to look into it more).~~ **Its not necessary**
- [x] Modify Documention (in `dinit` man page) (https://github.com/davmac314/dinit/pull/76/commits/fa14434a5363f080a56b35270c05b4afb37ca4c8)
- [x] Add myself to `CONTRIBUTORS` (https://github.com/davmac314/dinit/pull/76/commits/5440558f312a8710dd072e02ab47c4b2da7b8b94)

`Signed-off-by: Mobin <mobin@mobintestserver.ir>`