### PR TITLE
CI: some ci cleanup

### DIFF
--- a/.github/workflows/alpine-latest-aarch64.yml
+++ b/.github/workflows/alpine-latest-aarch64.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         arch: aarch64
         distro: alpine_latest
-        run: | 
+        run: |
           apk add ncurses
           echo "$(tput bold) Getting depends:$(tput sgr0) apk update && apk add make g++ m4 file"
           apk update
@@ -28,7 +28,7 @@ jobs:
           g++ -dumpmachine
           echo "$(tput bold) Build:$(tput sgr0) make"
           make
-          echo "$(tput bold) Print compiled file arch:$(tput sgr0) file"
+          echo "$(tput bold) Print dinit executive file architecture:$(tput sgr0) file ./src/dinit"
           file ./src/dinit
           export LSAN_OPTIONS=verbosity=1:log_threads=1
           echo "$(tput bold) Unit tests:$(tput sgr0) make check"

--- a/.github/workflows/alpine-latest-armv6.yml
+++ b/.github/workflows/alpine-latest-armv6.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         arch: armv6
         distro: alpine_latest
-        run: | 
+        run: |
           apk add ncurses
           echo "$(tput bold) Getting depends:$(tput sgr0) apk update && apk add make g++ m4 file"
           apk update
@@ -28,7 +28,7 @@ jobs:
           g++ -dumpmachine
           echo "$(tput bold) Build:$(tput sgr0) make"
           make
-          echo "$(tput bold) Print compiled file arch:$(tput sgr0) file"
+          echo "$(tput bold) Print dinit executive file architecture:$(tput sgr0) file ./src/dinit"
           file ./src/dinit
           export LSAN_OPTIONS=verbosity=1:log_threads=1
           echo "$(tput bold) Unit tests:$(tput sgr0) make check"

--- a/.github/workflows/alpine-latest-armv7.yml
+++ b/.github/workflows/alpine-latest-armv7.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         arch: armv7
         distro: alpine_latest
-        run: | 
+        run: |
           apk add ncurses
           echo "$(tput bold) Getting depends:$(tput sgr0) apk update && apk add make g++ m4 file"
           apk update
@@ -28,7 +28,7 @@ jobs:
           g++ -dumpmachine
           echo "$(tput bold) Build:$(tput sgr0) make"
           make
-          echo "$(tput bold) Print compiled file arch:$(tput sgr0) file"
+          echo "$(tput bold) Print dinit executive file architecture:$(tput sgr0) file ./src/dinit"
           file ./src/dinit
           export LSAN_OPTIONS=verbosity=1:log_threads=1
           echo "$(tput bold) Unit tests:$(tput sgr0) make check"

--- a/.github/workflows/debian-bullseye-amd64.yml
+++ b/.github/workflows/debian-bullseye-amd64.yml
@@ -17,18 +17,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Getting depends
-      run: apt-get update && apt-get install gcc make m4 g++ -y
-    - name: Print g++ arch
+      run: apt-get update && apt-get install gcc make m4 g++ file -y
+    - name: Print g++ architecture
       run: g++ -dumpmachine
-    - name: chmod +x configure
-      run: chmod +x ./configs/mconfig.Linux.sh
-    - name: configure
-      run: ./configs/mconfig.Linux.sh
     - name: Build
       run: make
-    - name: Install "file" package via apt-get
-      run: apt-get install file -y
-    - name: Print compiled file arch
+    - name: Print dinit executive file architecture
       run: file ./src/dinit
     - name: Unit tests
       run: make check

--- a/.github/workflows/debian-bullseye-i386.yml
+++ b/.github/workflows/debian-bullseye-i386.yml
@@ -19,18 +19,12 @@ jobs:
     - name: Add 32-bit repos
       run: dpkg --add-architecture i386
     - name: Getting depends
-      run: apt-get update && apt-get install gcc:i386 make:i386 m4:i386 g++:i386 -y
+      run: apt-get update && apt-get install gcc:i386 make:i386 m4:i386 g++:i386 file:i386 -y
     - name: Print g++ architecture
       run: g++ -dumpmachine
-    - name: chmod +x configure
-      run: chmod +x ./configs/mconfig.Linux.sh
-    - name: configure
-      run: ./configs/mconfig.Linux.sh
     - name: Build
       run: make
-    - name: Install "file" package via apt-get
-      run: apt-get install file -y
-    - name: Print dinit exec architecture
+    - name: Print dinit executive file architecture
       run: file ./src/dinit
     - name: Unit tests
       run: make check


### PR DESCRIPTION
## Goal
Better CI!

## ToDo
- [x] Remove unnecessary `configure` step from amd64/i386 CIs. its handeled by `make` command. (PR #78 Remove `configure` step from arm CIs)
- [x] Better titles for steps
- [x] a little cleanup (such as Remove unnecessary **spaces**)

`Signed-off-by: Mobin <mobin@mobintestserver.ir>`