### PR TITLE
Create mconfig.h for fuzzing

### DIFF
--- a/src/tests/cptests/Makefile
+++ b/src/tests/cptests/Makefile
@@ -48,7 +48,7 @@ fuzz_objects = $(foreach obj,$(parent_objs),fuzz-$(obj))
 include/mconfig.h: ../../../build/includes/mconfig.h
 	/usr/bin/env mv ../../../build/includes/mconfig.h includes/mconfig.h
 
-fuzz: prepare-incdir gen-mconfig fuzz.cc $(fuzz_parent_test_objects) $(fuzz_objects)
+fuzz: prepare-incdir include/mconfig.h fuzz.cc $(fuzz_parent_test_objects) $(fuzz_objects)
 	clang++ -std=c++11 -g -O1 -Iincludes -I../../../dasynq/include -fsanitize=fuzzer,address,undefined,leak fuzz.cc $(fuzz_parent_test_objects) $(fuzz_objects) -o fuzz
 
 $(fuzz_parent_test_objects): fuzz-%.o: ../%.cc

--- a/src/tests/cptests/Makefile
+++ b/src/tests/cptests/Makefile
@@ -45,7 +45,7 @@ fuzz_objects = $(foreach obj,$(parent_objs),fuzz-$(obj))
 ../../../build/includes/mconfig.h: ../../../mconfig
 	$(MAKE) -C ../../../build all
 
-fuzz: prepare-incdir ../../../build/include/mconfig.h fuzz.cc $(fuzz_parent_test_objects) $(fuzz_objects)
+fuzz: prepare-incdir ../../../build/includes/mconfig.h fuzz.cc $(fuzz_parent_test_objects) $(fuzz_objects)
 	clang++ -std=c++11 -g -O1 -Iincludes -I../../../dasynq/include -I../../../build/includes/ -fsanitize=fuzzer,address,undefined,leak fuzz.cc $(fuzz_parent_test_objects) $(fuzz_objects) -o fuzz
 
 $(fuzz_parent_test_objects): fuzz-%.o: ../%.cc

--- a/src/tests/cptests/Makefile
+++ b/src/tests/cptests/Makefile
@@ -45,17 +45,14 @@ fuzz_objects = $(foreach obj,$(parent_objs),fuzz-$(obj))
 ../../../build/includes/mconfig.h: ../../../mconfig
 	$(MAKE) -C ../../../build all
 
-include/mconfig.h: ../../../build/includes/mconfig.h
-	/usr/bin/env mv ../../../build/includes/mconfig.h includes/mconfig.h
-
-fuzz: prepare-incdir include/mconfig.h fuzz.cc $(fuzz_parent_test_objects) $(fuzz_objects)
-	clang++ -std=c++11 -g -O1 -Iincludes -I../../../dasynq/include -fsanitize=fuzzer,address,undefined,leak fuzz.cc $(fuzz_parent_test_objects) $(fuzz_objects) -o fuzz
+fuzz: prepare-incdir ../../../build/include/mconfig.h fuzz.cc $(fuzz_parent_test_objects) $(fuzz_objects)
+	clang++ -std=c++11 -g -O1 -Iincludes -I../../../dasynq/include -I../../../build/includes/ -fsanitize=fuzzer,address,undefined,leak fuzz.cc $(fuzz_parent_test_objects) $(fuzz_objects) -o fuzz
 
 $(fuzz_parent_test_objects): fuzz-%.o: ../%.cc
-	clang -O1 -fsanitize=address,undefined,fuzzer-no-link,leak -MMD -MP -Iincludes -I../../../dasynq/include -c $< -o $@
+	clang -O1 -fsanitize=address,undefined,fuzzer-no-link,leak -MMD -MP -Iincludes -I../../../dasynq/include -I../../../build/includes/ -c $< -o $@
 
 $(fuzz_objects): fuzz-%.o: ../../%.cc
-	clang -O1 -fsanitize=address,undefined,fuzzer-no-link,leak -MMD -MP -Iincludes -I../../../dasynq/include -c $< -o $@
+	clang -O1 -fsanitize=address,undefined,fuzzer-no-link,leak -MMD -MP -Iincludes -I../../../dasynq/include -I../../../build/includes/ -c $< -o $@
 
 
 -include $(objects:.o=.d)

--- a/src/tests/cptests/Makefile
+++ b/src/tests/cptests/Makefile
@@ -39,10 +39,14 @@ fuzz_parent_test_objects = $(foreach obj,$(notdir $(parent_test_objects)),fuzz-$
 fuzz_objects = $(foreach obj,$(parent_objs),fuzz-$(obj))
 
 # Create mconfig.h for fuzzing. because fuzz target not runned by top level make; we need to create mconfig.h manually.
-gen-mconfig:
-	$(MAKE) -C ../../../ mconfig
-	$(MAKE) -C ../../../build/tools/
-	../../../build/tools/mconfig-gen | tee includes/mconfig.h
+../../../mconfig:
+        $(MAKE) -C ../../../ mconfig
+
+../../../build/includes/mconfig.h: ../../../mconfig
+        $(MAKE) -C ../../../build all
+
+include/mconfig.h: ../../../build/includes/mconfig.h
+        /usr/bin/env mv ../../../build/includes/mconfig.h includes/mconfig.h
 
 fuzz: prepare-incdir gen-mconfig fuzz.cc $(fuzz_parent_test_objects) $(fuzz_objects)
 	clang++ -std=c++11 -g -O1 -Iincludes -I../../../dasynq/include -fsanitize=fuzzer,address,undefined,leak fuzz.cc $(fuzz_parent_test_objects) $(fuzz_objects) -o fuzz

--- a/src/tests/cptests/Makefile
+++ b/src/tests/cptests/Makefile
@@ -38,7 +38,13 @@ clean:
 fuzz_parent_test_objects = $(foreach obj,$(notdir $(parent_test_objects)),fuzz-$(obj))
 fuzz_objects = $(foreach obj,$(parent_objs),fuzz-$(obj))
 
-fuzz: prepare-incdir fuzz.cc $(fuzz_parent_test_objects) $(fuzz_objects)
+# Create mconfig.h for fuzzing. because fuzz target not runned by top level make; we need to create mconfig.h manually.
+gen-mconfig:
+	$(MAKE) -C ../../../ mconfig
+	$(MAKE) -C ../../../build/tools/
+	../../../build/tools/mconfig-gen | tee includes/mconfig.h
+
+fuzz: prepare-incdir gen-mconfig fuzz.cc $(fuzz_parent_test_objects) $(fuzz_objects)
 	clang++ -std=c++11 -g -O1 -Iincludes -I../../../dasynq/include -fsanitize=fuzzer,address,undefined,leak fuzz.cc $(fuzz_parent_test_objects) $(fuzz_objects) -o fuzz
 
 $(fuzz_parent_test_objects): fuzz-%.o: ../%.cc

--- a/src/tests/cptests/Makefile
+++ b/src/tests/cptests/Makefile
@@ -40,13 +40,13 @@ fuzz_objects = $(foreach obj,$(parent_objs),fuzz-$(obj))
 
 # Create mconfig.h for fuzzing. because fuzz target not runned by top level make; we need to create mconfig.h manually.
 ../../../mconfig:
-        $(MAKE) -C ../../../ mconfig
+	$(MAKE) -C ../../../ mconfig
 
 ../../../build/includes/mconfig.h: ../../../mconfig
-        $(MAKE) -C ../../../build all
+	$(MAKE) -C ../../../build all
 
 include/mconfig.h: ../../../build/includes/mconfig.h
-        /usr/bin/env mv ../../../build/includes/mconfig.h includes/mconfig.h
+	/usr/bin/env mv ../../../build/includes/mconfig.h includes/mconfig.h
 
 fuzz: prepare-incdir gen-mconfig fuzz.cc $(fuzz_parent_test_objects) $(fuzz_objects)
 	clang++ -std=c++11 -g -O1 -Iincludes -I../../../dasynq/include -fsanitize=fuzzer,address,undefined,leak fuzz.cc $(fuzz_parent_test_objects) $(fuzz_objects) -o fuzz


### PR DESCRIPTION
because fuzz target not runned by top level make; we need to create mconfig.h manually.

Fixes #91

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`