### PR TITLE
CI: Fuzzer for dinit!

### DIFF
--- a/.github/workflows/ubuntu-latest-amd64-fuzzer.yml
+++ b/.github/workflows/ubuntu-latest-amd64-fuzzer.yml
@@ -1,0 +1,28 @@
+name: Dinit on ubuntu-latest-amd64 fuzzer
+
+on:
+  workflow_dispatch:
+
+jobs:
+  Ubuntu-latest-amd64_fuzzer:
+
+    runs-on: ubuntu-latest
+    
+    # We need to upload crash* files after libfuzzer fail so disable fail-fast option
+    strategy:
+      fail-fast: false
+    
+    steps:
+    - uses: actions/checkout@v3
+    - name: Print clang++ architecture
+      run: clang++ -dumpmachine
+    - name: Build `fuzz` target via make
+      run: cd src/tests/cptests/ && make fuzz
+    - name: Run fuzzer
+      run: src/tests/cptests/fuzz -max_total_time=21000
+    - name: Upload crash file(s)
+      uses: actions/upload-artifact@v3.1.0
+      if: failure()
+      with:
+          name: Dinit-fuzzer_crash
+          path: src/tests/cptests/fuzz/crash*

--- a/.github/workflows/ubuntu-latest-amd64-minifuzzer.yml
+++ b/.github/workflows/ubuntu-latest-amd64-minifuzzer.yml
@@ -23,10 +23,10 @@ jobs:
     - name: Build `fuzz` target via make
       run: cd src/tests/cptests/ && make fuzz
     - name: Run fuzzer
-      run: src/tests/cptests/fuzz -max_total_time=12
+      run: src/tests/cptests/fuzz -max_total_time=1200
     - name: Upload crash file(s)
       uses: actions/upload-artifact@v3.1.0
-      if: failure() && steps.build.outcome == 'success'
+      if: failure()
       with:
-          name: Dinit-minifuzzer_crash-$(date)
+          name: Dinit-minifuzzer_crash
           path: src/tests/cptests/fuzz/crash*

--- a/.github/workflows/ubuntu-latest-amd64-minifuzzer.yml
+++ b/.github/workflows/ubuntu-latest-amd64-minifuzzer.yml
@@ -1,0 +1,22 @@
+name: Dinit on ubuntu-latest-amd64 minifuzzer
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+jobs:
+  Ubuntu-latest-amd64_minifuzzer:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Print clang++ architecture
+      run: clang++ -dumpmachine
+    - name: Build `fuzz` target via make
+      run: cd src/tests/cptests/ && make fuzz
+    - name: Run fuzzer
+      run: src/tests/cptests/fuzz -max_total_time=1200

--- a/.github/workflows/ubuntu-latest-amd64-minifuzzer.yml
+++ b/.github/workflows/ubuntu-latest-amd64-minifuzzer.yml
@@ -11,7 +11,11 @@ jobs:
   Ubuntu-latest-amd64_minifuzzer:
 
     runs-on: ubuntu-latest
-
+    
+    # We need to upload crash* files after libfuzzer fail so disable fail-fast option
+    strategy:
+      fail-fast: false
+    
     steps:
     - uses: actions/checkout@v3
     - name: Print clang++ architecture
@@ -19,4 +23,10 @@ jobs:
     - name: Build `fuzz` target via make
       run: cd src/tests/cptests/ && make fuzz
     - name: Run fuzzer
-      run: src/tests/cptests/fuzz -max_total_time=1200
+      run: src/tests/cptests/fuzz -max_total_time=12
+    - name: Upload crash file(s)
+      uses: actions/upload-artifact@v3.1.0
+      if: failure() && steps.build.outcome == 'success'
+      with:
+          name: Dinit-minifuzzer_crash-$(date)
+          path: src/tests/cptests/fuzz/crash*


### PR DESCRIPTION
## Goal
Provide auto fuzzer for dinit project on github CI
## ToDo
- [x] Write "minifuzzer" its runned for 20 min & runs for every commits/PRs such as other workflows
- [x] Write "fuzzer" its runned for 5 hours & 50 min but dont run for every commits/PRs, this is have `workflow_dispatch:` for run it manually
- [x] Provide artifacts to upload crash(s)
- [ ] We need to run fuzzer for multiarch? I think: no!

Fixes #90 

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`