### PR TITLE
Linux services example: modules.sh: Use `grep -E` instead of `egrep`

### DIFF
--- a/doc/linux/services/modules.sh
+++ b/doc/linux/services/modules.sh
@@ -9,7 +9,7 @@ case "${1}" in
     start)
 
         # Exit if there's no modules file or there are no valid entries
-        [ -r ${MODULES} ] && egrep -qv '^($|#)' ${MODULES} || exit 0
+        [ -r ${MODULES} ] && grep -Eqv '^($|#)' ${MODULES} || exit 0
 
         while read module args; do
 


### PR DESCRIPTION
## Goal
Use `grep -E` instead of `egrep` in `/doc/linux/services/modules.sh` file
> Why?

because GNU grep developers in [GNU grep 3.8 release notice](https://lists.gnu.org/archive/html/info-gnu/2022-09/msg00001.html) said:
>  The egrep and fgrep commands, which have been deprecated since
  release 2.5.3 (2007), now warn that they are obsolescent and should
  be replaced by grep -E and grep -F.

## ToDo
- [x] Use `grep -E` instead of `egrep` in `/doc/linux/services/modules.sh` file

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`