### PR TITLE
Allow restart of services if all dependents restart automatically

### DIFF
--- a/src/dinitctl.cc
+++ b/src/dinitctl.cc
@@ -1181,6 +1181,9 @@ static int service_status(int socknum, cpbuffer_t &rbuffer, const char *service_
         case service_state_t::STOPPED:
             cout << "STOPPED";
             switch (stop_reason) {
+            case stopped_reason_t::DEPRESTART:
+                cout << " (dependency restarted)";
+                break;
             case stopped_reason_t::DEPFAILED:
                 cout << " (dependency failed/terminated)";
                 break;

--- a/src/includes/control.h
+++ b/src/includes/control.h
@@ -179,7 +179,13 @@ class control_conn_t : private service_listener
     // Check if any dependents will be affected by stopping a service, generate a response packet if so.
     // had_dependents will be set true if the service should not be stopped, false otherwise.
     // Returns false if the connection must be closed, true otherwise.
-    bool check_dependents(service_record *service, bool do_restart, bool &had_dependents);
+    bool check_dependents(service_record *service, bool &had_dependents);
+
+    // Check if any dependents will be affected by restarting a service if gentle, otherwise check if
+    // any pinned started dependents will be affected, generate a response packet if so.
+    // had_dependents will be set true if the service should not be restarted, false otherwise.
+    // Returns false if the connection must be closed, true otherwise.
+    bool check_restart_dependents(service_record *service, bool gentle, bool &had_dependents);
 
     // Allocate a new handle for a service; may throw std::bad_alloc
     handle_t allocate_service_handle(service_record *record);

--- a/src/includes/control.h
+++ b/src/includes/control.h
@@ -179,7 +179,7 @@ class control_conn_t : private service_listener
     // Check if any dependents will be affected by stopping a service, generate a response packet if so.
     // had_dependents will be set true if the service should not be stopped, false otherwise.
     // Returns false if the connection must be closed, true otherwise.
-    bool check_dependents(service_record *service, bool &had_dependents);
+    bool check_dependents(service_record *service, bool do_restart, bool &had_dependents);
 
     // Allocate a new handle for a service; may throw std::bad_alloc
     handle_t allocate_service_handle(service_record *record);

--- a/src/includes/service-constants.h
+++ b/src/includes/service-constants.h
@@ -45,6 +45,7 @@ enum class shutdown_type_t {
 enum class stopped_reason_t
 {
     NORMAL,
+    DEPRESTART, // A hard dependency was restarted
 
     // Start failures:
     DEPFAILED, // A dependency failed to start

--- a/src/includes/service.h
+++ b/src/includes/service.h
@@ -273,6 +273,7 @@ class service_record
     bool start_skipped : 1;     // start was skipped by interrupt
     
     bool in_auto_restart : 1;
+    bool in_user_restart : 1;
 
     int required_by = 0;        // number of dependents wanting this service to be started
 
@@ -356,7 +357,10 @@ class service_record
     bool stop_check_dependents() noexcept;
     
     // issue a stop to all dependents, return true if they are all already stopped
-    bool stop_dependents(bool for_restart) noexcept;
+    bool stop_dependents(bool with_restart, bool for_restart) noexcept;
+
+    // issue a restart to all hard dependents
+    bool restart_dependents() noexcept;
     
     void require() noexcept;
     void release(bool issue_stop = true) noexcept;
@@ -437,7 +441,7 @@ class service_record
             waiting_for_console(false), have_console(false), waiting_for_execstat(false),
             start_explicit(false), prop_require(false), prop_release(false), prop_failure(false),
             prop_start(false), prop_stop(false), start_failed(false), start_skipped(false),
-            in_auto_restart(false), force_stop(false)
+            in_auto_restart(false), in_user_restart(false), force_stop(false)
     {
         services = set;
         record_type = service_type_t::DUMMY;

--- a/src/tests/tests.cc
+++ b/src/tests/tests.cc
@@ -391,6 +391,74 @@ void basic_test8()
     assert(sset.count_active_services() == 0);
 }
 
+// A hard dependent service which restarts due to a requested dependency restart should restart,
+// a soft dependent service should be left untouched.
+void basic_test9()
+{
+    service_set sset;
+
+    test_service *s1 = new test_service(&sset, "test-service-1", service_type_t::INTERNAL, {});
+    test_service *s2 = new test_service(&sset, "test-service-2", service_type_t::INTERNAL, {{s1, REG}});
+    test_service *s3 = new test_service(&sset, "test-service-3", service_type_t::INTERNAL, {{s2, REG}});
+    test_service *s4 = new test_service(&sset, "test-service-4", service_type_t::INTERNAL, {{s1, MS}});
+    sset.add_service(s1);
+    sset.add_service(s2);
+    sset.add_service(s3);
+    sset.add_service(s4);
+
+    assert(sset.find_service("test-service-1") == s1);
+    assert(sset.find_service("test-service-2") == s2);
+    assert(sset.find_service("test-service-3") == s3);
+    assert(sset.find_service("test-service-4") == s4);
+
+    // Start all four services:
+    sset.start_service(s3);
+    sset.start_service(s4);
+
+    s1->started();
+    sset.process_queues();
+    s2->started();
+    sset.process_queues();
+    s3->started();
+    sset.process_queues();
+    s4->started();
+    sset.process_queues();
+
+    assert(s4->get_state() == service_state_t::STARTED);
+    assert(s3->get_state() == service_state_t::STARTED);
+    assert(s2->get_state() == service_state_t::STARTED);
+    assert(s1->get_state() == service_state_t::STARTED);
+
+    // Now restart s1, which should also force s2 and s3 to restart.
+    // s2 (and therefore s1) should restart:
+    s1->restart();
+    sset.process_queues();
+
+    // s4 only has a milestone dependency, and should be left untouched.
+    assert(s4->get_state() == service_state_t::STARTED);
+    assert(s3->get_state() == service_state_t::STARTING);
+    assert(s2->get_state() == service_state_t::STARTING);
+    assert(s1->get_state() == service_state_t::STARTING);
+
+    assert(s4->get_target_state() == service_state_t::STARTED);
+    assert(s3->get_target_state() == service_state_t::STARTED);
+    assert(s2->get_target_state() == service_state_t::STARTED);
+    assert(s1->get_target_state() == service_state_t::STARTED);
+
+    s1->started();
+    sset.process_queues();
+    s2->started();
+    sset.process_queues();
+    s3->started();
+    sset.process_queues();
+
+    assert(s4->get_state() == service_state_t::STARTED);
+    assert(s3->get_state() == service_state_t::STARTED);
+    assert(s2->get_state() == service_state_t::STARTED);
+    assert(s1->get_state() == service_state_t::STARTED);
+    assert(sset.count_active_services() == 4);
+}
+
 // Test that service pinned in start state is not stopped when its dependency stops.
 void test_pin1()
 {
@@ -1573,6 +1641,7 @@ int main(int argc, char **argv)
     RUN_TEST(basic_test6, "               ");
     RUN_TEST(basic_test7, "               ");
     RUN_TEST(basic_test8, "               ");
+    RUN_TEST(basic_test9, "               ");
     RUN_TEST(test_pin1, "                 ");
     RUN_TEST(test_pin2, "                 ");
     RUN_TEST(test_pin3, "                 ");


### PR DESCRIPTION
I have an issue where I need to restart pipewire and its dependents (`pipewire-pulse`, `wireplumber`).

With this change I can restart the `pipewire` service which will stop all the dependents and then restart pipewire which results in the dependents being started again since its made sure that all dependents of pipewire have `restart = true`.

Not sure if the check for `!pinned_started` is correct, but it seems logical to now allow restarts if the dependent is pinned started.

Another way would be to allow `--force` again for restarts, but that leaves the services in a bad state if a dependent doesn't restart on its own.