### PR TITLE
Example linux services: rootfscheck.sh: Fix #117

### DIFF
--- a/doc/linux/services/rootfscheck.sh
+++ b/doc/linux/services/rootfscheck.sh
@@ -2,9 +2,9 @@
 export PATH=/usr/bin:/usr/sbin:/bin:/sbin
 
 if [ "$1" != "stop" ]; then
-  
-  ROOTDEV=`findmnt -o SOURCE -n -M /`
-  
+
+  ROOTDEV=`eval $(lsblk -oMOUNTPOINT,NAME -P | grep 'MOUNTPOINT="/"'); echo /dev/"$NAME"`
+
   echo "Checking root file system (^C to skip)..."
   if [ -x /sbin/fsck ]; then
     /sbin/fsck -C -a "$ROOTDEV"
@@ -28,5 +28,5 @@ if [ "$1" != "stop" ]; then
   else
     echo "WARNING - Could not find /sbin/fsck"
   fi
-  
+
 fi;

--- a/doc/linux/services/rootfscheck.sh
+++ b/doc/linux/services/rootfscheck.sh
@@ -3,7 +3,7 @@ export PATH=/usr/bin:/usr/sbin:/bin:/sbin
 
 if [ "$1" != "stop" ]; then
 
-  ROOTDEV=`eval $(lsblk -oMOUNTPOINT,NAME -P | grep 'MOUNTPOINT="/"'); echo /dev/"$NAME"`
+  ROOTDEV=`findmnt -v -o SOURCE -n -M /`
 
   echo "Checking root file system (^C to skip)..."
   if [ -x /sbin/fsck ]; then


### PR DESCRIPTION
## Goal
Fixes #117 
## ToDo
- [x] Fix broken root checking when btrfs subvolume is used in `/doc/linux/service/rootfscheck.sh` file

`Signed-off-by: Mobin <mobin@mobintestserver.ir>`