### PR TITLE
Clear errno after trying multiple service dirs

### DIFF
--- a/src/load-service.cc
+++ b/src/load-service.cc
@@ -296,6 +296,8 @@ service_record * dirload_service_set::load_reload_service(const char *name, serv
             fail_load_path = std::move(service_filename);
         }
     }
+    // We want to clear errno as the service may have been missing in some paths
+    errno = 0;
 
     if (!service_file) {
         if (fail_load_errno == 0) {


### PR DESCRIPTION
The previous code would remain errno to be set after trying bad service directories (despite having encountered a valid one later), which would result in nonsensical error messages outside that path.