### PR TITLE
make: mconfig.Linux.sh: Prefer c++ instead of g++

### DIFF
--- a/configs/mconfig.Linux.sh
+++ b/configs/mconfig.Linux.sh
@@ -35,7 +35,7 @@ test_compile_link_arg() {
   fi
 }
 
-for compiler in g++ clang++ c++ ""; do
+for compiler in c++ clang++ g++ ""; do
   if test -z "$compiler"; then
     break # none found
   fi


### PR DESCRIPTION
Hi!
On most systems; `c++` is main c++ compiler. For example debian setting `clang++` or `g++` as `c++` exec via `update-alternatives`. so let's follow them!

`Signed-off-by: Mobin "Hojjat" Aydinfar <mobin@mobintestserver.ir>`