### PR TITLE
make: Some fixes to `make clean`

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -58,7 +58,7 @@ endif
 
 clean:
 	rm -f *.o *.d
-	rm -f dinit dinitctl dinitcheck shutdown
+	rm -f dinit dinitctl dinitcheck shutdown dinit-monitor
 	$(MAKE) -C tests clean
 	$(MAKE) -C igr-tests clean
 

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -42,7 +42,7 @@ $(parent_objs): %.o: ../%.cc
 
 clean:
 	$(MAKE) -C cptests clean
-	rm -f *.o *.d tests proctests loadtests
+	rm -f *.o *.d tests proctests loadtests envtests
 
 -include $(objects:.o=.d)
 -include $(parent_objs:.o=.d)


### PR DESCRIPTION
Seems like in some cases `/src/tests/envtests` and `/src/dinit-monitor` not removed by `make check` command. This patch fix those issues.

Regards

`Signed-off-by: Mobin 'hojjat' Aydinfar <mobin@mobintestserver.ir>`