### PR TITLE
make: pass SANITIZEOPTS last

### DIFF
--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -16,16 +16,16 @@ run-tests: tests proctests loadtests envtests
 	$(MAKE) -C cptests run-tests
 
 tests: $(parent_objs) tests.o test-dinit.o test-bpsys.o test-run-child-proc.o
-	$(CXX) $(SANITIZEOPTS) -o tests $(parent_objs) tests.o test-dinit.o test-bpsys.o test-run-child-proc.o $(CXXOPTS) $(LDFLAGS)
+	$(CXX) -o tests $(parent_objs) tests.o test-dinit.o test-bpsys.o test-run-child-proc.o $(CXXOPTS) $(LDFLAGS) $(SANITIZEOPTS)
 
 proctests: $(parent_objs) proctests.o test-dinit.o test-bpsys.o test-run-child-proc.o
-	$(CXX) $(SANITIZEOPTS) -o proctests $(parent_objs) proctests.o test-dinit.o test-bpsys.o test-run-child-proc.o $(CXXOPTS) $(LDFLAGS)
+	$(CXX) -o proctests $(parent_objs) proctests.o test-dinit.o test-bpsys.o test-run-child-proc.o $(CXXOPTS) $(LDFLAGS) $(SANITIZEOPTS)
 	
 loadtests: $(parent_objs) loadtests.o test-dinit.o test-bpsys.o test-run-child-proc.o
-	$(CXX) $(SANITIZEOPTS) -o loadtests $(parent_objs) loadtests.o test-dinit.o test-bpsys.o test-run-child-proc.o $(CXXOPTS) $(LDFLAGS)
+	$(CXX) -o loadtests $(parent_objs) loadtests.o test-dinit.o test-bpsys.o test-run-child-proc.o $(CXXOPTS) $(LDFLAGS) $(SANITIZEOPTS)
 
 envtests: $(parent_objs) envtests.o test-dinit.o test-bpsys.o test-run-child-proc.o
-	$(CXX) $(SANITIZEOPTS) -o envtests $(parent_objs) envtests.o test-dinit.o test-bpsys.o test-run-child-proc.o $(CXXOPTS) $(LDFLAGS)
+	$(CXX) -o envtests $(parent_objs) envtests.o test-dinit.o test-bpsys.o test-run-child-proc.o $(CXXOPTS) $(LDFLAGS) $(SANITIZEOPTS)
 
 $(objects): %.o: %.cc
 	$(CXX) $(CXXOPTS) $(SANITIZEOPTS) -MMD -MP -Iincludes -I../../dasynq/include -I../../build/includes -c $< -o $@

--- a/src/tests/cptests/Makefile
+++ b/src/tests/cptests/Makefile
@@ -12,7 +12,7 @@ run-tests: cptests
 	./cptests
 
 cptests: cptests.o $(parent_objs) $(parent_test_objs)
-	$(CXX) $(SANITIZEOPTS) -o cptests cptests.o $(parent_test_objects) $(parent_objs) $(CXXOPTS) $(LDFLAGS)
+	$(CXX) -o cptests cptests.o $(parent_test_objects) $(parent_objs) $(CXXOPTS) $(LDFLAGS) $(SANITIZEOPTS)
 
 $(objects): %.o: %.cc
 	$(CXX) $(CXXOPTS) $(SANITIZEOPTS) -MMD -MP -Iincludes -I../../../dasynq/include -I../../../build/includes -c $< -o $@


### PR DESCRIPTION
As things are, user-passed flags override the sanitizer options that are used for tests. The UBSan sanitizer has a minimal runtime option, which can be used in production due to minimal overhead while still printing reasonable messages. However, this minimal runtime is not compatible with ASan, which is used for tests by default, therefore it is necessary to disable this minimal runtime for those files.

Unless SANITIZEOPTS are passed last, the potential minimal-runtime option passed from flags used for the rest of the build may result in failed test builds when SANITIZEOPTS contain ASan. Even if passed last, one still gotta disable the minimal runtime inside of SANITIZEOPTS, but that is something the user can control.