### PR TITLE
Make: igr-tests and src/: Some cleanup for `make clean`

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -58,7 +58,7 @@ endif
 
 clean:
 	rm -f *.o *.d
-	rm -f dinit dinitctl dinitcheck shutdown dinit-monitor
+	rm -f dinit dinitctl dinitcheck $(SHUTDOWN_PREFIX)shutdown dinit-monitor
 	$(MAKE) -C tests clean
 	$(MAKE) -C igr-tests clean
 

--- a/src/igr-tests/Makefile
+++ b/src/igr-tests/Makefile
@@ -7,8 +7,8 @@ igr-runner: igr-runner.cc
 	$(CXX) $(CXXOPTS) igr-runner.cc -o igr-runner
 
 clean:
-	rm -f igr-runner basic/basic-ran environ/env-record ps-environ/env-record chain-to/recorded-output
+	rm -f igr-runner basic/basic-ran environ/env-record ps-environ/env-record chain-to/recorded-output var-subst/args-record
 	rm -f restart/basic-ran
-	rm -f check-basic/output.txt check-cycle/output.txt
+	rm -f check-basic/output.txt check-lint/output.txt check-cycle/output.txt no-command-error/dinit-run.log
 	rm -rf reload1/sd
 	rm -rf reload2/sd


### PR DESCRIPTION
Hi!
"Sometimes we forget when add a new feature be careful about `make clean` command and add new things to that. It's a example."

`src/igr-tests/check-lint/output.txt`, `src/igr-tests/no-command-error/dinit-run.log` and `src/igr-tests/var-subst/args-record` not removes by `make clean` Also when `SHUTDOWN_PREFIX` is used, its have a same story. This patch fix this these things.

P.S: I working on packaging `dinit` for Debian and I have a plan to add it to Debian official repos. These things finded by `debuild -us -uc` command.

Regards

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`