### PR TITLE
substitute env-file in service files at load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 # Integration test output:
 /src/igr-tests/basic/basic-ran
 /src/igr-tests/environ/env-record
+/src/igr-tests/environ2/env-record
 /src/igr-tests/ps-environ/env-record
 /src/igr-tests/chain-to/recorded-output
 /src/igr-tests/restart/basic-ran

--- a/doc/manpages/dinit-service.5.m4
+++ b/doc/manpages/dinit-service.5.m4
@@ -349,11 +349,14 @@ This directive can be specified multiple times to set additional options.
 .TP
 \fBload\-options\fR = \fIload_option\fR...
 Specifies options for interpreting other settings when loading this service description.
-Currently there is only one available option, \fBexport-passwd-vars\fR, which specifies that
-the environment variables `\fBUSER\fR', `\fBLOGNAME\fR' (same as `\fBUSER\fR'),
-`\fBHOME\fR', `\fBSHELL\fR', `\fBUID\fR', and `\fBGID\fR' should be exported into the
-service's load environment (that is, overriding any global environment including the
-global environment file, but being overridable by the service's environment file).
+Currently there are two available options. One is \fBexport-passwd-vars\fR, which
+specifies that the environment variables `\fBUSER\fR', `\fBLOGNAME\fR' (same as
+`\fBUSER\fR'), `\fBHOME\fR', `\fBSHELL\fR', `\fBUID\fR', and `\fBGID\fR' should
+be exported into the service's load environment (that is, overriding any global
+environment including the global environment file, but being overridable by the
+service's environment file). The other is \fBexport-service-name\fR, which will
+set the environment variable `\fBDINIT_SERVICE\fR' containing the name of the
+current service.
 .TP
 \fBinittab\-id\fR = \fIid-string\fR
 When this service is started, if this setting (or the \fBinittab\-line\fR setting) has a

--- a/src/igr-tests/Makefile
+++ b/src/igr-tests/Makefile
@@ -7,7 +7,7 @@ igr-runner: igr-runner.cc
 	$(CXX) $(CXXFLAGS) $(CXXFLAGS_EXTRA) $(LDFLAGS) $(LDFLAGS_EXTRA) igr-runner.cc -o igr-runner
 
 clean:
-	rm -f igr-runner basic/basic-ran environ/env-record ps-environ/env-record chain-to/recorded-output var-subst/args-record
+	rm -f igr-runner basic/basic-ran environ/env-record environ2/env-record ps-environ/env-record chain-to/recorded-output var-subst/args-record
 	rm -f restart/basic-ran
 	rm -f check-basic/output.txt check-lint/output.txt check-cycle/output.txt no-command-error/dinit-run.log
 	rm -rf reload1/sd

--- a/src/igr-tests/environ/checkenv.sh
+++ b/src/igr-tests/environ/checkenv.sh
@@ -2,6 +2,9 @@
 
 if [ "$TEST_VAR_ONE" = "hello" ]; then
     echo "$DINIT_SOCKET_PATH" >> ./env-record
+    if [ "$2" = "$DINIT_SERVICE" ]; then
+        echo "$DINIT_SERVICE" >> ./env-record
+    fi
 fi
 
 if [ "$1" = "hello" ]; then

--- a/src/igr-tests/environ/checkenv.sh
+++ b/src/igr-tests/environ/checkenv.sh
@@ -4,4 +4,10 @@ if [ "$TEST_VAR_ONE" = "hello" ]; then
     echo "$DINIT_SOCKET_PATH" >> ./env-record
 fi
 
+if [ "$1" = "hello" ]; then
+    echo gotenv1 >> ./env-record
+elif [ "$1" = "goodbye" ]; then
+    echo gotenv2 >> ./env-record
+fi
+
 echo "$TEST_VAR_ONE" >> ./env-record

--- a/src/igr-tests/environ/run-test.sh
+++ b/src/igr-tests/environ/run-test.sh
@@ -19,7 +19,7 @@ rm -f ./env-record
 
 STATUS=FAIL
 if [ -e env-record ]; then
-   if [ "$(cat env-record)" = "$(echo $DINIT_SOCKET_PATH; echo gotenv1; echo hello; echo gotenv2; echo goodbye; echo 3; echo 2; echo 1)" ]; then
+   if [ "$(cat env-record)" = "$(echo $DINIT_SOCKET_PATH; echo checkenv; echo gotenv1; echo hello; echo gotenv2; echo goodbye; echo 3; echo 2; echo 1)" ]; then
        STATUS=PASS
    fi
 fi

--- a/src/igr-tests/environ/run-test.sh
+++ b/src/igr-tests/environ/run-test.sh
@@ -19,7 +19,7 @@ rm -f ./env-record
 
 STATUS=FAIL
 if [ -e env-record ]; then
-   if [ "$(cat env-record)" = "$(echo $DINIT_SOCKET_PATH; echo hello; echo goodbye; echo 3; echo 2; echo 1)" ]; then
+   if [ "$(cat env-record)" = "$(echo $DINIT_SOCKET_PATH; echo gotenv1; echo hello; echo gotenv2; echo goodbye; echo 3; echo 2; echo 1)" ]; then
        STATUS=PASS
    fi
 fi

--- a/src/igr-tests/environ/sd/checkenv
+++ b/src/igr-tests/environ/sd/checkenv
@@ -1,3 +1,3 @@
 type = process
-command = ./checkenv.sh
+command = ./checkenv.sh $TEST_VAR_ONE
 restart = false

--- a/src/igr-tests/environ/sd/checkenv
+++ b/src/igr-tests/environ/sd/checkenv
@@ -1,3 +1,4 @@
 type = process
-command = ./checkenv.sh $TEST_VAR_ONE
+command = ./checkenv.sh $TEST_VAR_ONE $DINIT_SERVICE
 restart = false
+load-options = export-service-name

--- a/src/igr-tests/environ2/checkenv.sh
+++ b/src/igr-tests/environ2/checkenv.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+echo "$TEST_VAR" >> ./env-record
+echo "$TEST_VAR_BASE" >> ./env-record
+echo "$TEST_VAR_ONE" >> ./env-record
+echo "$USER" >> ./env-record
+echo "$LOGNAME" >> ./env-record
+echo "$SHELL" >> ./env-record
+echo "$UID" >> ./env-record
+echo "$GID" >> ./env-record

--- a/src/igr-tests/environ2/env-dinit
+++ b/src/igr-tests/environ2/env-dinit
@@ -1,0 +1,4 @@
+TEST_VAR_BASE=hello
+TEST_VAR_ONE=world
+# this is set per-service, so override will do nothing
+LOGNAME=dinit-igr-test

--- a/src/igr-tests/environ2/env-service
+++ b/src/igr-tests/environ2/env-service
@@ -1,0 +1,3 @@
+TEST_VAR_ONE=override
+# so we know we can override it from here
+SHELL=/bogus/value

--- a/src/igr-tests/environ2/run-test.sh
+++ b/src/igr-tests/environ2/run-test.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+cd "$(dirname "$0")"
+
+export DINIT_SOCKET_PATH="$(pwd)/socket"
+
+rm -f ./env-record
+
+RUSER=$(id -nu)
+RUID=$(id -u)
+RGID=$(id -g)
+
+# unset to make sure dinit can initialize this itself
+unset USER
+unset LOGNAME
+unset SHELL
+unset UID
+unset GID
+
+# test whether vars from global environment propagate
+export TEST_VAR="helloworld"
+
+"$DINIT_EXEC" -d sd -u -p socket -q \
+        -e env-dinit \
+	checkenv
+
+USER="$RUSER"
+# we try to override this one in env-dinit, but it should be set per-service
+LOGNAME="$USER"
+# these are overriden in env files
+SHELL="/bogus/value"
+
+STATUS=FAIL
+if [ -e env-record ]; then
+   if [ "$(cat env-record)" = "$(echo helloworld; echo hello; echo override; echo $USER; echo $LOGNAME; echo $SHELL; echo $RUID; echo $RGID)" ]; then
+       STATUS=PASS
+   fi
+fi
+
+if [ $STATUS = PASS ]; then exit 0; fi
+exit 1

--- a/src/igr-tests/environ2/sd/checkenv
+++ b/src/igr-tests/environ2/sd/checkenv
@@ -1,0 +1,5 @@
+type = process
+command = ./checkenv.sh $TEST_VAR_ONE $TEST_VAR_BASE
+restart = false
+env-file = env-service
+load-options = export-passwd-vars

--- a/src/igr-tests/igr-runner.cc
+++ b/src/igr-tests/igr-runner.cc
@@ -12,7 +12,7 @@ extern char **environ;
 
 int main(int argc, char **argv)
 {
-    const char * const test_dirs[] = { "basic", "environ", "ps-environ", "chain-to", "force-stop",
+    const char * const test_dirs[] = { "basic", "environ", "environ2", "ps-environ", "chain-to", "force-stop",
             "restart", "check-basic", "check-cycle", "check-lint", "reload1", "reload2", "no-command-error",
             "add-rm-dep", "var-subst", "svc-start-fail", "dep-not-found" };
     constexpr int num_tests = sizeof(test_dirs) / sizeof(test_dirs[0]);

--- a/src/igr-tests/var-subst/checkargs.sh
+++ b/src/igr-tests/var-subst/checkargs.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-echo 1:"$1" 2:"$2" 3:"$3" >> ./args-record
+echo 1:"$1" 2:"$2" 3:"$3" 4:"$4" >> ./args-record

--- a/src/igr-tests/var-subst/run-test.sh
+++ b/src/igr-tests/var-subst/run-test.sh
@@ -10,7 +10,7 @@ export TEST_VAR_ONE="var one" TEST_VAR_TWO=vartwo TEST_VAR_THREE=varthree
 
 STATUS=FAIL
 if [ -e args-record ]; then
-   if [ "$(cat args-record)" = "1:xxxvar one/yyy 2:vartwovarthree 3:" ]; then
+   if [ "$(cat args-record)" = "1:xxxvar one/yyy 2:vartwovarthree 3:varfour 4:" ]; then
        STATUS=PASS
    fi
 fi

--- a/src/igr-tests/var-subst/sd/checkargs
+++ b/src/igr-tests/var-subst/sd/checkargs
@@ -1,4 +1,3 @@
 type = process
-command = ./checkargs.sh xxx$TEST_VAR_ONE/yyy $TEST_VAR_TWO$TEST_VAR_THREE
-load-options = sub-vars
+command = ./checkargs.sh xxx$TEST_VAR_ONE/yyy ${TEST_VAR_TWO}$TEST_VAR_THREE ${TEST_VAR_FOUR:-varfour}
 restart = false

--- a/src/includes/dinit-env.h
+++ b/src/includes/dinit-env.h
@@ -95,6 +95,14 @@ public:
 
         // map of variable name (via string_view) to its index in env_list
         std::unordered_map<string_view, unsigned, hash_sv> var_map;
+
+        const char *lookup(string_view sv) const {
+            auto it = var_map.find(sv);
+            if (it != var_map.end()) {
+                return env_list[it->second] + sv.size() + 1;
+            }
+            return nullptr;
+        }
     };
 
     // return environment variable in form NAME=VALUE. Assumes that the real environment is the parent.

--- a/src/includes/load-service.h
+++ b/src/includes/load-service.h
@@ -804,6 +804,7 @@ class service_settings_wrapper
     string env_file;
 
     bool export_passwd_vars = false;
+    bool export_service_name = false;
 
     service_type_t service_type = service_type_t::INTERNAL;
     list<dep_type> depends;
@@ -1175,6 +1176,9 @@ void process_service_line(settings_wrapper &settings, const char *name, string &
                     indexpair.second - indexpair.first);
             if (option_txt == "export-passwd-vars") {
                 settings.export_passwd_vars = true;
+            }
+            else if (option_txt == "export-service-name") {
+                settings.export_service_name = true;
             }
             else if (option_txt == "sub-vars") {
                 // noop: for backwards compatibility only

--- a/src/includes/service.h
+++ b/src/includes/service.h
@@ -249,6 +249,8 @@ class service_record
     protected:
     service_flags_t onstart_flags;
     
+    environment service_env; // holds the environment populated during load
+
     bool auto_restart : 1;    // whether to restart this (process) if it dies unexpectedly
     bool smooth_recovery : 1; // whether the service process can restart without bringing down service
 
@@ -517,6 +519,11 @@ class service_record
     bool is_marked_active() noexcept
     {
         return start_explicit;
+    }
+
+    void set_environment(environment &&env) noexcept
+    {
+        this->service_env = std::move(env);
     }
 
     // Set whether this service should automatically restart when it dies

--- a/src/load-service.cc
+++ b/src/load-service.cc
@@ -364,6 +364,13 @@ service_record * dirload_service_set::load_reload_service(const char *name, serv
             fill_environment_userinfo(settings.run_as_uid, name, srv_env);
         }
 
+        /* set service name in environment if desired */
+        if (settings.export_service_name) {
+            std::string envname = "DINIT_SERVICE=";
+            envname += name;
+            srv_env.set_var(std::move(envname));
+        }
+
         // this mapping is temporary, for load substitutions
         // the reason for this is that the environment actually *may* change
         // after load, e.g. through dinitctl setenv (either from the outside

--- a/src/tests/test-services/t2
+++ b/src/tests/test-services/t2
@@ -1,3 +1,2 @@
 type = process
-load-options = sub-vars
-command = echo $ONEVAR $TWOVAR $THREEVAR
+command = echo $ONEVAR ${ONEVAR} ${ONEVAR+b} ${ONEVAR:+b} $TWOVAR ${TWOVAR} ${TWOVAR-world} ${TWOVAR:-world} $THREEVAR ${THREEVAR} ${THREEVAR+empty} ${THREEVAR:+empty} ${THREEVAR-empty} ${THREEVAR:-empty} $FOURVAR ${FOURVAR} ${FOURVAR+empty2} ${FOURVAR:+empty2} ${FOURVAR-empty2} ${FOURVAR:-empty2}


### PR DESCRIPTION
The previous behavior did not substitute env-file variables at service load, because it could only see the environment available to dinit process. This changes that, and env-files are instead loaded during service load, and all variables are substituted.

The vars set up during process call are not exposed here. These would have limited usability in any case and would significantly complicate the whole thing.

I am putting this here to get comments. The code is not necessarily good/clean, e.g. dinitcheck is not properly implemented at this point, and there are no tests yet. I mostly want to know if continuing with this approach is okay. The referenced issue from @Duncaen also talks about implementing basic variable substitutions, I still gotta think about those. I think a well defined subset would be nice, though I see that being more useful in the service files themselves rather than in the env-file (e.g. to substitute defaults when there is no env-file or the variable is missing from env-file). I am also not implementing the default variables, I will do that once this is okay.

My original approach involved building the environment map once and then passing that to the child process, and doing the additional variable setting directly on that. However, this turned out not working because the desired environment may change between load and run through changes of base dinit process environment, e.g. via `dinitctl setenv`. If we were to do that we'd have to scan for all loaded service and update each's maps, which is no good.

Ref https://github.com/davmac314/dinit/issues/109