### PR TITLE
CI: Use `matrix` for more clean FreeBSD CIs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,17 +1,8 @@
-Dinit on freebsd-13.1-amd64 CI_task:
+Dinit on freebsd-amd64 CI_task:
   freebsd_instance:
-    image_family: freebsd-13-1
-
-  Getting depends_script: pkg update && ASSUME_ALWAYS_YES=YES pkg install gmake m4 file
-  Print clang++ architecture_script: clang++ -dumpmachine
-  Build_script: gmake
-  Print dinit executive file architecture_script: file ./src/dinit
-  Unit tests_script: gmake check
-  Integration tests_script: gmake check-igr
-
-Dinit on freebsd-12.3-amd64 CI_task:
-  freebsd_instance:
-    image_family: freebsd-12-3
+    matrix:
+      - image_family: freebsd-13-1
+      - image_family: freebsd-12-3
 
   Getting depends_script: pkg update && ASSUME_ALWAYS_YES=YES pkg install gmake m4 file
   Print clang++ architecture_script: clang++ -dumpmachine


### PR DESCRIPTION
It's more cleaner.

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`