### PR TITLE
Swap AND to OR, fix `--log-file` when in system mode.

### DIFF
--- a/src/dinit.cc
+++ b/src/dinit.cc
@@ -576,7 +576,7 @@ int dinit_main(int argc, char **argv)
     
     // Only try to set up the external log now if we aren't the system init. (If we are the
     // system init, wait until the log service starts).
-    if (!am_system_init && log_specified) setup_external_log();
+    if (!am_system_init || log_specified) setup_external_log();
 
     if (env_file != nullptr) {
         read_env_file(env_file, true, main_env);


### PR DESCRIPTION
Easiest PR, ever. :)

Fixes #147 

Tried it locally on my OpenWrt router, works exactly as expected.

```
root@FriendlyWrt /s/o/dinit (master)# /etc/init.d/dinit restart
root@FriendlyWrt /s/o/dinit (master)# ls /var/log
caddy.dinit.log  caddy.log  dinit.log  lastlog  log.nmbd  log.smbd  mysql  php8-fpm.log  rclone  samba  tor  wtmp  www.access.log
root@FriendlyWrt /s/o/dinit (master)# tail -f /var/log/dinit.log
dinit: Starting system
dinit: service caddy started.
dinit: service boot started.
^C⏎
root@FriendlyWrt /s/o/dinit (master) [SIGINT]# ps -ef | grep dinit
29095 root      0:00 /sbin/dinit -d /sdcard/dinit.d --log-file /var/log/dinit.log
```