### PR TITLE
CI: Don't run cirrus-ci when something like `README.md` changes

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,21 @@
 Dinit on freebsd-amd64 CI_task:
+  skip: "changesIncludeOnly('.github/**',
+                             'README.md',
+                             'NEWS',
+                             'BUILD*',
+                             'CONTRIBUTORS',
+                             'TODO',
+                             'LICENSE',
+                             'build/includes/README',
+                             'doc/CODE-STYLE',
+                             'doc/COMPARISON',
+                             'doc/CONTRIBUTING',
+                             'doc/DESIGN',
+                             'doc/getting_started.md',
+                             'doc/manpages/README',
+                             'doc/manpages/generate-html.sh',
+                             'doc/manpages/DINIT-AS-INIT.md',
+                             'doc/linux/**')"
   freebsd_instance:
     matrix:
       - image_family: freebsd-13-1


### PR DESCRIPTION
Hi

## Goal
Don't run cirrus-ci when something like `README.md` changes. (Changes already made for Github CI in https://github.com/davmac314/dinit/pull/132)

## ToDo
- [x] Don't run cirrus-ci when something like `README.md` changes.

Regards

`Signed-off-by: Mobin "Hojjat" Aydinfar <mobin@mobintestserver.ir>`