### PR TITLE
CI: Use `DEBIAN_FRONTEND=noninteractive` in Debian CI(s)

### DIFF
--- a/.github/workflows/regular_ci.yml
+++ b/.github/workflows/regular_ci.yml
@@ -69,12 +69,12 @@ jobs:
       if: ${{ matrix.arch == 'amd64' }}
       run: |
         apt-get update
-        apt-get install g++ make m4 file -y
+        DEBIAN_FRONTEND=noninteractive apt-get install g++ make m4 file -y
     - name: Getting depends (i386)
       if: ${{ matrix.arch == 'i386' }}
       run: |
         apt-get update
-        apt-get install gcc:i386 make:i386 m4:i386 g++:i386 file -y
+        DEBIAN_FRONTEND=noninteractive apt-get install gcc:i386 make:i386 m4:i386 g++:i386 file -y
     - name: Print g++ architecture
       run: g++ -dumpmachine
     - name: Build


### PR DESCRIPTION
It's helps us to avoid these things in CI logs:
```
...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.32.1 /usr/local/share/perl/5.32.1 /usr/lib/x86_64-linux-gnu/perl5/5.32 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.32 /usr/share/perl/5.32 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype
...
```

Regards

`Signed-off-by: Mobin "Hojjat" Aydinfar <mobin@mobintestserver.ir>`