### PR TITLE
Feature signal support

### DIFF
--- a/doc/manpages/dinitctl.8.m4
+++ b/doc/manpages/dinitctl.8.m4
@@ -70,6 +70,9 @@ dinitctl \- control services supervised by Dinit
 .HP
 .B dinitctl
 [\fIoptions\fR] \fBcatlog\fR [\fB--clear\fR] \fIservice-name\fR
+.HP
+.B dinitctl
+[\fIoptions\fR] \fBsignal\fR ( \fB\-\-list/\-l\fR | \fIsignal-number\fR \fIservice-name\fR )
 .\"
 .PD
 .hy
@@ -313,6 +316,18 @@ Show the contents of the log buffer for the named service.
 This is possible only if the log type of the service is set to \fBbuffer\fR.
 If the log is truncated or appears incomplete, a warning message follows the output.
 If the \fB\-\-clear\fR option is specified, the buffer is cleared after displaying its contents. 
+.TP
+\fBsignal\fR
+Send a signal to a specified service.
+The \fIsignal-number\fR can either be specified as integer or signal name.
+Signal names are only defined for these signals:
+\fBHUP\fR, \fBKILL\fR, \fBUSR1\fR, \fBUSR2\fR, \fBSTOP\fR, \fBINT\fR, \fBTERM\fR,
+\fBCONT\fR, \fBQUIT\fR and if system supports it; \fBINFO\fR.
+Other system specific signals, like Linux real-time signals, have to be specified as integer.
+Dinit will accept any signal which supported by \fBkill(2)\fR syscall.
+.sp
+The \fB--list\fR or \fB-l\fR option can be used (instead of \fIsignal-number\fR and \fIservice-name\fR)
+to list available signal names and their corresponding integer value for the current platform/system.
 .\"
 .SH SERVICE OPERATION
 .\"

--- a/src/includes/control-cmds.h
+++ b/src/includes/control-cmds.h
@@ -60,6 +60,9 @@ constexpr static int DINIT_CP_SETTRIGGER = 19;
 // Retrieve buffered output
 constexpr static int DINIT_CP_CATLOG = 20;
 
+// Send Signal to process
+constexpr static int DINIT_CP_SIGNAL = 21;
+
 
 // Replies:
 
@@ -125,6 +128,10 @@ constexpr static int DINIT_RP_SERVICE_LOAD_ERR = 72;
 // Service log:
 constexpr static int DINIT_RP_SERVICE_LOG = 73;
 
+// Signal replies:
+constexpr static int DINIT_RP_SIGNAL_NOPID = 74;
+constexpr static int DINIT_RP_SIGNAL_BADSIG = 75;
+constexpr static int DINIT_RP_SIGNAL_KILLERR = 76;
 
 // Information (out-of-band):
 

--- a/src/includes/control.h
+++ b/src/includes/control.h
@@ -165,6 +165,9 @@ class control_conn_t : private service_listener
     // Process a CATLOG packet.
     bool process_catlog();
 
+    // Process a SIGNAL packet.
+    bool process_signal();
+
     // List all loaded services and their state.
     bool list_services();
 

--- a/src/includes/load-service.h
+++ b/src/includes/load-service.h
@@ -150,18 +150,36 @@ inline string_iterator skipws(string_iterator i, string_iterator end) noexcept
     return i;
 }
 
-// Convert a signal name to the corresponding signal number
-inline int signal_name_to_number(std::string &signame) noexcept
+// The list to converting some strings/signals to int
+// The signal list is created statically with only those signals,
+// which are defined for the current architecture/system
+const std::pair<const char *, int> signal_to_int_map[] = {
+    { "none", 0 },
+    { "NONE", 0 },
+    { "HUP", SIGHUP },
+    { "INT", SIGINT },
+    { "QUIT", SIGQUIT },
+    { "KILL", SIGKILL },
+    { "USR1", SIGUSR1 },
+    { "USR2", SIGUSR2 },
+    { "TERM", SIGTERM },
+    { "CONT", SIGCONT },
+    { "STOP", SIGSTOP },
+#ifdef SIGINFO
+    { "INFO", SIGINFO },
+#endif
+};
+
+inline int signal_name_to_number(const std::string &signame) noexcept
 {
-    if (signame == "none" || signame == "NONE") return 0;
-    if (signame == "HUP") return SIGHUP;
-    if (signame == "INT") return SIGINT;
-    if (signame == "TERM") return SIGTERM;
-    if (signame == "QUIT") return SIGQUIT;
-    if (signame == "USR1") return SIGUSR1;
-    if (signame == "USR2") return SIGUSR2;
-    if (signame == "KILL") return SIGKILL;
-    return -1;
+    int sig = -1;
+    for (const auto &signal: signal_to_int_map) {
+        if (signal.first == signame) {
+            sig = signal.second;
+            break;
+        }
+    }
+    return sig;
 }
 
 // Read a setting/variable name; return empty string if no valid name

--- a/src/tests/proctests.cc
+++ b/src/tests/proctests.cc
@@ -8,6 +8,7 @@
 #include "service.h"
 #include "proc-service.h"
 #include "dinit-util.h"
+#include "test_procservice.h"
 
 // Tests of process-service related functionality.
 //
@@ -18,67 +19,6 @@ extern eventloop_t event_loop;
 
 constexpr static auto REG = dependency_type::REGULAR;
 constexpr static auto WAITS = dependency_type::WAITS_FOR;
-
-// Friend interface to access base_process_service private/protected members.
-class base_process_service_test
-{
-    public:
-    static void exec_succeeded(base_process_service *bsp)
-    {
-        bsp->waiting_for_execstat = false;
-        bsp->exec_succeeded();
-    }
-
-    static void exec_failed(base_process_service *bsp, int errcode)
-    {
-        run_proc_err err;
-        err.stage = exec_stage::DO_EXEC;
-        err.st_errno = errcode;
-        bsp->waiting_for_execstat = false;
-        bsp->pid = -1;
-        bsp->exec_failed(err);
-    }
-
-    static void handle_exit(base_process_service *bsp, int exit_status)
-    {
-        bsp->pid = -1;
-        bsp->handle_exit_status(bp_sys::exit_status(true, false, exit_status));
-    }
-
-    static void handle_signal_exit(base_process_service *bsp, int signo)
-    {
-        bsp->pid = -1;
-        bsp->handle_exit_status(bp_sys::exit_status(false, true, signo));
-    }
-
-    static void handle_stop_exit(process_service *ps, int exit_status)
-    {
-        ps->stop_pid = -1;
-        ps->waiting_for_execstat = false;
-        ps->stop_status = bp_sys::exit_status(true, false, exit_status);
-        ps->handle_stop_exit();
-    }
-
-    static int get_notification_fd(base_process_service *bsp)
-    {
-        return bsp->notification_fd;
-    }
-};
-
-namespace bp_sys {
-    // last signal sent:
-    extern int last_sig_sent;
-    extern pid_t last_forked_pid;
-}
-
-static time_val default_restart_interval = time_val(0, 200000000); // 200 milliseconds
-
-static void init_service_defaults(base_process_service &ps)
-{
-    ps.set_restart_interval(time_val(10,0), 3);
-    ps.set_restart_delay(default_restart_interval); // 200 milliseconds
-    ps.set_stop_timeout(time_val(10,0));
-}
 
 // Regular service start
 void test_proc_service_start()

--- a/src/tests/test_procservice.h
+++ b/src/tests/test_procservice.h
@@ -1,0 +1,65 @@
+#ifndef TEST_PROCSERVICE
+#define TEST_PROCSERVICE
+
+// Friend interface to access base_process_service private/protected members.
+class base_process_service_test
+{
+    public:
+    static void exec_succeeded(base_process_service *bsp)
+    {
+        bsp->waiting_for_execstat = false;
+        bsp->exec_succeeded();
+    }
+
+    static void exec_failed(base_process_service *bsp, int errcode)
+    {
+        run_proc_err err;
+        err.stage = exec_stage::DO_EXEC;
+        err.st_errno = errcode;
+        bsp->waiting_for_execstat = false;
+        bsp->pid = -1;
+        bsp->exec_failed(err);
+    }
+
+    static void handle_exit(base_process_service *bsp, int exit_status)
+    {
+        bsp->pid = -1;
+        bsp->handle_exit_status(bp_sys::exit_status(true, false, exit_status));
+    }
+
+    static void handle_signal_exit(base_process_service *bsp, int signo)
+    {
+        bsp->pid = -1;
+        bsp->handle_exit_status(bp_sys::exit_status(false, true, signo));
+    }
+
+    static void handle_stop_exit(process_service *ps, int exit_status)
+    {
+        ps->stop_pid = -1;
+        ps->waiting_for_execstat = false;
+        ps->stop_status = bp_sys::exit_status(true, false, exit_status);
+        ps->handle_stop_exit();
+    }
+
+    static int get_notification_fd(base_process_service *bsp)
+    {
+        return bsp->notification_fd;
+    }
+};
+
+namespace bp_sys {
+    // last signal sent:
+    extern int last_sig_sent;
+    extern pid_t last_forked_pid;
+}
+
+static time_val default_restart_interval = time_val(0, 200000000); // 200 milliseconds
+
+static void init_service_defaults(base_process_service &ps)
+{
+    ps.set_restart_interval(time_val(10,0), 3);
+    ps.set_restart_delay(default_restart_interval); // 200 milliseconds
+    ps.set_stop_timeout(time_val(10,0));
+}
+
+#endif /* TEST_PROCSERVICE */


### PR DESCRIPTION
This adds support for sending signals to services, as I consider it a generally useful feature and implemented it with hacky scripts parsing the output of `dinitctl status $service` in the past. Many services use signals for reloading configuration files and/or enabling/disabling specific runtime features. The feature is currently requested by #134 and @davmac314 commented that
> it's something that is planned

As this would be my first contribution to the project I appreciate any feedback. I'm willing to implement changes/improvements.

I've tried to follow contribution guidelines. Tests are still missing. I will add them if the feature is generally considered accepted.
 - [x]  should follow existing style and conventions
 - [x] should keep the design considerations in mind (read the DESIGN document)
 - [x] should be accompanied by appropriate documentation additions/updates
 - [ ] should include tests where practical
 
Open questions/limitations:
- Should signalling be moved from `control.cc` directly as a feature into the (decedents of the) `service_record` class ?
- I've found no way to translate signal names/abbrevations to their integer counterparts at runtime, that is system and architecture independent. The [`sigabbrev_np`](https://man7.org/linux/man-pages/man3/strsignal.3.html) function is a gnu extension and only works for non realtime signals. [Here](https://github.com/util-linux/util-linux/blob/master/lib/signames.c#L130) is how `kill` from `util-linux` does it, but I'm not sure if this kind of conversion is worth it.