### PR TITLE
baseproc-service: fix default log target for none-logged services

### DIFF
--- a/src/baseproc-service.cc
+++ b/src/baseproc-service.cc
@@ -106,7 +106,7 @@ bool base_process_service::start_ps_process(const std::vector<const char *> &cmd
     }
 
     const char * logfile = this->logfile.c_str();
-    if (this->log_type == log_type_id::LOGFILE) {
+    if (this->log_type == log_type_id::LOGFILE || this->log_type == log_type_id::NONE) {
     	if (*logfile == 0) {
     		logfile = "/dev/null";
     	}


### PR DESCRIPTION
We need to treat NONE (which is the default) the same as LOGFILE, so that we get a default /dev/null target. Otherwise, it is treated as BUFFER by default, which is undesirable, as processes will suddenly start hanging as soon as they run out of buffer space.