### PR TITLE
dinit-service: `logfile-permissions`, `logfile-uid`, `logfile-gid` opts

### DIFF
--- a/doc/manpages/dinit-service.5.m4
+++ b/doc/manpages/dinit-service.5.m4
@@ -360,6 +360,23 @@ This setting has no effect if the service is set to run on the console (via the 
 \fBstarts\-on\-console\fR, or \fBshares\-console\fR options).
 The value is subject to variable substitution (see \fBVARIABLE SUBSTITUTION\fR).
 .TP
+\fBlogfile\-permissions\fR = \fIoctal-permissions-mask\fR
+Gives the permissions for the logfile specified using \fBlogfile\fR. Normally this will be 600 (user access
+only), 640 (also readable by the group), or 644 (readable by all users).
+The default is 600.
+If the logfile already exists when the service starts, its permissions will be changed to those specified with this setting.
+.TP
+\fBlogfile\-uid\fR = {\fInumeric-user-id\fR | \fIusername\fR}
+Specifies the user (name or numeric ID) that should own the logfile.
+If \fBlogfile\-uid\fR is specified as a name without also specifying \fBlogfile-gid\fR, then
+the logfile group is the primary group of the specified user (as found in the
+system user database, normally \fI/etc/passwd\fR).
+If the logfile already exists when the service starts, its ownership will be changed according to the value of this setting.
+The default value is the user id of the \fBdinit\fR process.
+.TP
+\fBlogfile\-gid\fR = {\fInumeric-group-id\fR | \fIgroup-name\fR}
+Specifies the group of the logfile. See discussion of \fBlogfile\-uid\fR.
+.TP
 \fBoptions\fR = \fIoption\fR...
 Specifies various options for this service. See the \fBOPTIONS\fR section.
 This directive can be specified multiple times to set additional options.

--- a/src/includes/proc-service.h
+++ b/src/includes/proc-service.h
@@ -176,7 +176,10 @@ class base_process_service : public service_record
     string env_file;          // file with environment settings for this service
 
     log_type_id log_type = log_type_id::NONE;
-    string logfile;           // log file name, empty string specifies /dev/null
+    string logfile;          // log file name, empty string specifies /dev/null
+    int logfile_perms = 0;   // logfile permissions("mode")
+    uid_t logfile_uid = -1;  // logfile owner user id
+    gid_t logfile_gid = -1;  // logfile group id
     unsigned log_buf_max = 0; // log buffer maximum size
     unsigned log_buf_size = 0; // log buffer current size
     std::vector<char, default_init_allocator<char>> log_buffer;
@@ -346,10 +349,13 @@ class base_process_service : public service_record
         stop_arg_parts = std::move(command_parts);
     }
 
-    // Set logfile (used if log mode is FILE)
-    void set_log_file(std::string &&logfile) noexcept
+    void set_logfile_details(string &&logfile, int logfile_perms, uid_t logfile_uid, gid_t logfile_gid)
+            noexcept
     {
         this->logfile = std::move(logfile);
+        this->logfile_perms = logfile_perms;
+        this->logfile_uid = logfile_uid;
+        this->logfile_gid = logfile_gid;
     }
 
     // Set log buffer maximum size (for if mode is BUFFER). Maximum allowed size is UINT_MAX / 2

--- a/src/load-service.cc
+++ b/src/load-service.cc
@@ -648,7 +648,8 @@ service_record * dirload_service_set::load_reload_service(const char *name, serv
             rvalps->set_run_as_uid_gid(settings.run_as_uid, settings.run_as_gid);
             rvalps->set_notification_fd(settings.readiness_fd);
             rvalps->set_notification_var(std::move(settings.readiness_var));
-            rvalps->set_log_file(std::move(settings.logfile));
+            rvalps->set_logfile_details(std::move(settings.logfile), settings.logfile_perms,
+                    settings.logfile_uid, settings.logfile_gid);
             rvalps->set_log_buf_max(settings.max_log_buffer_sz);
             rvalps->set_log_mode(settings.log_type);
             #if USE_UTMPX
@@ -689,7 +690,8 @@ service_record * dirload_service_set::load_reload_service(const char *name, serv
             rvalps->set_start_timeout(settings.start_timeout);
             rvalps->set_extra_termination_signal(settings.term_signal);
             rvalps->set_run_as_uid_gid(settings.run_as_uid, settings.run_as_gid);
-            rvalps->set_log_file(std::move(settings.logfile));
+            rvalps->set_logfile_details(std::move(settings.logfile), settings.logfile_perms,
+                    settings.logfile_uid, settings.logfile_gid);
             rvalps->set_log_buf_max(settings.max_log_buffer_sz);
             rvalps->set_log_mode(settings.log_type);
             settings.onstart_flags.runs_on_console = false;
@@ -724,7 +726,8 @@ service_record * dirload_service_set::load_reload_service(const char *name, serv
             rvalps->set_start_timeout(settings.start_timeout);
             rvalps->set_extra_termination_signal(settings.term_signal);
             rvalps->set_run_as_uid_gid(settings.run_as_uid, settings.run_as_gid);
-            rvalps->set_log_file(std::move(settings.logfile));
+            rvalps->set_logfile_details(std::move(settings.logfile), settings.logfile_perms,
+                    settings.logfile_uid, settings.logfile_gid);
             rvalps->set_log_buf_max(settings.max_log_buffer_sz);
             rvalps->set_log_mode(settings.log_type);
         }

--- a/src/run-child-proc.cc
+++ b/src/run-child-proc.cc
@@ -211,6 +211,12 @@ void base_process_service::run_child_proc(run_proc_params params) noexcept
             if (output_fd == -1) {
                 output_fd = open(logfile, O_WRONLY | O_CREAT | O_APPEND, S_IRUSR | S_IWUSR);
                 if (output_fd == -1) goto failure_out;
+                // Set permission of logfile if present
+                // if log type is NONE, we don't want to change ownership/permissions of /dev/null!
+                if (this->log_type == log_type_id::LOGFILE) {
+                    if (fchown(output_fd, logfile_uid, logfile_gid) == -1) goto failure_out;
+                    if (fchmod(output_fd, logfile_perms) == -1) goto failure_out;
+                }
             }
             if (notify_fd != 1) {
                 if (move_fd(output_fd, 1) != 0) {


### PR DESCRIPTION
Hi!

Some new options in services: `logfile-permissions`, `logfile-uid`, `logfile-gid`.

ToDo
- [x] Options
- [x] Fix weird `assert()` failure
- [x] Commit message
- [x] Docs and ~changelog~ notes

It's mostly ready but We need to discuss about some things:
- [x] Perms, ~uid and gid~ will changed for each run, so if a logfile exist, those things will changed to service options or dinit defaults. I think it's better than old behavior (keep file perms). if it's ok I need to note this thing in commit message, changelog and 0.17 release notes.
- [x] ~New `option` for match logfile-uid with run-as user uid?~ (Not needed)

Best regards
Fixes #193

`Signed-off-by: Mobin "Hojjat" Aydinfar <mobin@mobintestserver.ir>`