### PR TITLE
CI: Minor improvements

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,21 +1,10 @@
 Dinit on freebsd-amd64 CI_task:
-  skip: "changesIncludeOnly('.github/**',
-                             'README.md',
-                             'NEWS',
-                             'BUILD*',
-                             'CONTRIBUTORS',
-                             'TODO',
-                             'LICENSE',
-                             'build/includes/README',
-                             'doc/CODE-STYLE',
-                             'doc/COMPARISON',
-                             'doc/CONTRIBUTING',
-                             'doc/DESIGN',
-                             'doc/getting_started.md',
-                             'doc/manpages/README',
-                             'doc/manpages/generate-html.sh',
-                             'doc/manpages/DINIT-AS-INIT.md',
-                             'doc/linux/**')"
+  skip: "!changesInclude('.cirrus.yml',
+                         'build/**',
+                         'configs/**',
+                         'dasynq/**',
+                         'src/**',
+                         '**/Makefile')"
   freebsd_instance:
     matrix:
       - image_family: freebsd-13-1

--- a/.github/workflows/meson_ci.yml
+++ b/.github/workflows/meson_ci.yml
@@ -7,25 +7,13 @@ on:
     branches:
       - master
     paths:
-      - '**'
+      - '.github/workflows/meson_ci.yml'
       - 'build/version.conf'
-      - '!.*'
-      - '!README.md'
-      - '!NEWS'
-      - '!BUILD*'
-      - '!CONTRIBUTORS'
-      - '!TODO'
-      - '!LICENSE'
-      - '!**/Makefile'
-      - '!build/**'
-      - '!doc/CODE-STYLE'
-      - '!doc/COMPARISON'
-      - '!doc/CONTRIBUTING'
-      - '!doc/DESIGN'
-      - '!doc/getting_started.md'
-      - '!doc/manpages/README'
-      - '!doc/manpages/generate-html.sh'
-      - '!doc/linux/**'
+      - 'configs/**'
+      - 'dasynq/**'
+      - 'src/**'
+      - '**/meson.build'
+      - 'meson_options.txt'
   pull_request:
     types:
       - labeled
@@ -35,25 +23,13 @@ on:
     branches:
       - master
     paths:
-      - '**'
+      - '.github/workflows/meson_ci.yml'
       - 'build/version.conf'
-      - '!.*'
-      - '!README.md'
-      - '!NEWS'
-      - '!BUILD*'
-      - '!CONTRIBUTORS'
-      - '!TODO'
-      - '!LICENSE'
-      - '!**/Makefile'
-      - '!build/**'
-      - '!doc/CODE-STYLE'
-      - '!doc/COMPARISON'
-      - '!doc/CONTRIBUTING'
-      - '!doc/DESIGN'
-      - '!doc/getting_started.md'
-      - '!doc/manpages/README'
-      - '!doc/manpages/generate-html.sh'
-      - '!doc/linux/**'
+      - 'configs/**'
+      - 'dasynq/**'
+      - 'src/**'
+      - '**/meson.build'
+      - 'meson_options.txt'
   workflow_dispatch:
 
 jobs:
@@ -65,6 +41,7 @@ jobs:
     container:
       image: debian:bullseye
     strategy:
+      fail-fast: false # Upload src/igr-tests/*/output/* files in igr-tests
       matrix:
         include:
           - arch: 'amd64'
@@ -93,12 +70,19 @@ jobs:
       run: meson test -v --suite=unit_tests -C dirbuild
     - name: Integration tests
       run: meson test -v --suite=igr_tests -C dirbuild
+    - name: Upload igr-tests output file(s) on failure
+      uses: actions/upload-artifact@v3.1.2
+      if: failure()
+      with:
+          name: igr-tests_output
+          path: dirbuild/src/igr-tests/*/output/*
 
   MacOS-latest_build:
 
     if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'meson') }}
     runs-on: macos-latest
     strategy:
+      fail-fast: false # Upload src/igr-tests/*/output/* files in igr-tests
       matrix:
         include:
           - arch: 'amd64'
@@ -117,12 +101,19 @@ jobs:
       run: meson test -v --suite=unit_tests -C dirbuild
     - name: Integration tests
       run: meson test -v --suite=igr_tests -C dirbuild
+    - name: Upload igr-tests output file(s) on failure
+      uses: actions/upload-artifact@v3.1.2
+      if: failure()
+      with:
+          name: igr-tests_output
+          path: dirbuild/src/igr-tests/*/output/*
 
   Alpine-latest_build:
 
     if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'meson') }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false # Upload src/igr-tests/*/output/* files in igr-tests
       matrix:
         include:
           - arch: 'armv6'
@@ -150,3 +141,9 @@ jobs:
           meson test -v --suite=unit_tests -C dirbuild
           echo "$(tput bold) ----Integration tests---- :$(tput sgr0) meson test -v --suite=igr_tests -C dirbuild"
           meson test -v --suite=igr_tests -C dirbuild
+    - name: Upload igr-tests output file(s) on failure
+      uses: actions/upload-artifact@v3.1.2
+      if: failure()
+      with:
+          name: igr-tests_output
+          path: dirbuild/src/igr-tests/*/output/*

--- a/.github/workflows/regular_ci.yml
+++ b/.github/workflows/regular_ci.yml
@@ -5,46 +5,24 @@ on:
     branches:
       - master
     paths:
-      - '**'
-      - '!.*'
-      - '!README.md'
-      - '!NEWS'
-      - '!BUILD*'
-      - '!CONTRIBUTORS'
-      - '!TODO'
-      - '!LICENSE'
+      - '.github/workflows/regular_ci.yml'
+      - 'build/**'
+      - 'configs/**'
+      - 'dasynq/**'
+      - 'src/**'
+      - '**/Makefile'
       - '!build/includes/README'
-      - '!doc/CODE-STYLE'
-      - '!doc/COMPARISON'
-      - '!doc/CONTRIBUTING'
-      - '!doc/DESIGN'
-      - '!doc/getting_started.md'
-      - '!doc/manpages/README'
-      - '!doc/manpages/generate-html.sh'
-      - '!doc/manpages/DINIT-AS-INIT.md'
-      - '!doc/linux/**'
   pull_request:
     branches:
       - master
     paths:
-      - '**'
-      - '!.*'
-      - '!README.md'
-      - '!NEWS'
-      - '!BUILD*'
-      - '!CONTRIBUTORS'
-      - '!TODO'
-      - '!LICENSE'
+      - '.github/workflows/regular_ci.yml'
+      - 'build/**'
+      - 'configs/**'
+      - 'dasynq/**'
+      - 'src/**'
+      - '**/Makefile'
       - '!build/includes/README'
-      - '!doc/CODE-STYLE'
-      - '!doc/COMPARISON'
-      - '!doc/CONTRIBUTING'
-      - '!doc/DESIGN'
-      - '!doc/getting_started.md'
-      - '!doc/manpages/README'
-      - '!doc/manpages/generate-html.sh'
-      - '!doc/manpages/DINIT-AS-INIT.md'
-      - '!doc/linux/**'
   workflow_dispatch:
 
 jobs:
@@ -55,6 +33,7 @@ jobs:
     container:
       image: debian:bullseye
     strategy:
+      fail-fast: false # Upload src/igr-tests/*/output/* files in igr-tests
       matrix:
         include:
           - arch: 'amd64'
@@ -84,12 +63,19 @@ jobs:
     - name: Unit tests
       run: make check
     - name: Integration tests
-      run: make check-igr
+      run: make check-igr DEBUG=1
+    - name: Upload igr-tests output file(s) on failure
+      uses: actions/upload-artifact@v3.1.2
+      if: failure()
+      with:
+          name: igr-tests_output
+          path: src/igr-tests/*/output/*
 
   MacOS-latest_build:
 
     runs-on: macos-latest
     strategy:
+      fail-fast: false # Upload src/igr-tests/*/output/* files in igr-tests
       matrix:
         include:
           - arch: 'amd64'
@@ -109,12 +95,19 @@ jobs:
     - name: Unit tests
       run: make check
     - name: Integration tests
-      run: make check-igr
+      run: make check-igr DEBUG=1
+    - name: Upload igr-tests output file(s) on failure
+      uses: actions/upload-artifact@v3.1.2
+      if: failure()
+      with:
+          name: igr-tests_output
+          path: src/igr-tests/*/output/*
 
   Alpine-latest_build:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false # Upload src/igr-tests/*/output/* files in igr-tests
       matrix:
         include:
           - arch: 'armv6'
@@ -142,5 +135,11 @@ jobs:
           file ./src/dinit
           echo "$(tput bold) ----Unit tests---- :$(tput sgr0) make check"
           make check
-          echo "$(tput bold) ----Integration tests---- :$(tput sgr0) make check-igr"
-          make check-igr
+          echo "$(tput bold) ----Integration tests---- :$(tput sgr0) make check-igr DEBUG=1"
+          make check-igr DEBUG=1
+    - name: Upload igr-tests output file(s) on failure
+      uses: actions/upload-artifact@v3.1.2
+      if: failure()
+      with:
+          name: igr-tests_output
+          path: src/igr-tests/*/output/*


### PR DESCRIPTION
Hey.

ToDo:

- [x] Don't run Make based CI for Meson files changes
- [x] Don't run FreeBSD CI for Meson files changes
- [x] Upload `src/igr-tests/*/output/*` files on failure (Github actions only)
- [x] Add `DEBUG=1` flag to `make check-igr` in Make based CI

Regards

`Signed-off-by: Mobin "Hojjat" Aydinfar <mobin@mobintestserver.ir>`