### PR TITLE
dinit: show in `--version` if dinit was compiled with initgroups

### DIFF
--- a/src/dinit.cc
+++ b/src/dinit.cc
@@ -1116,6 +1116,9 @@ static void printVersion()
 #ifdef USE_UTMPX
             +1
 #endif
+#if USE_INITGROUPS
+            +1
+#endif
             ;
     if (feature_count != 0) {
         std::cout << "Supported features:"
@@ -1124,6 +1127,9 @@ static void printVersion()
 #endif
 #ifdef USE_UTMPX
                 " utmp"
+#endif
+#if USE_INITGROUPS
+                " supplemental-groups"
 #endif
                 "\n";
     }


### PR DESCRIPTION
I think it's useful to allow checking it via `dinit -v`

`Signed-off-by: Mobin "Hojjat" Aydinfar <mobin@mobintestserver.ir>`