### PR TITLE
meson: Include `option-processing` for compiling dinitctl

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -41,6 +41,7 @@ executable(
 executable(
     'dinitctl',
     'dinitctl.cc',
+    'options-processing.cc',
     include_directories : default_incdir,
     install : true,
     install_dir : sbindir


### PR DESCRIPTION
Fixes meson CI failure due to 788d65f commit

`Signed-off-by: Mobin "Hojjat" Aydinfar <mobin@mobintestserver.ir>`