### PR TITLE
load-service: throw an error if the "consumer" service is its own consumer

### DIFF
--- a/src/includes/load-service.h
+++ b/src/includes/load-service.h
@@ -1171,6 +1171,10 @@ void process_service_line(settings_wrapper &settings, const char *name, string &
     }
     else if (setting == "consumer-of") {
         string consumed_svc_name = read_setting_value(line_num, i, end);
+        if (consumed_svc_name == name) {
+            throw service_description_exc(name, "service cannot be its own consumer",
+                    line_num);
+        }
         settings.consumer_of_name = consumed_svc_name;
     }
     else if (setting == "restart") {


### PR DESCRIPTION
Hi.
In the past, the dinitctl command to start that service would just hang and dinit would mark that service as STOPPED without any reason in its reports.

`Signed-off-by: Mobin "Hojjat" Aydinfar <mobin@mobintestserver.ir>`