### PR TITLE
dinit: Treat failure in reading env-file as hard error

### DIFF
--- a/src/dinit-env.cc
+++ b/src/dinit-env.cc
@@ -18,10 +18,15 @@ static void log_bad_env_cmd(int linenum)
 }
 
 // Read and set environment variables from a file. May throw std::bad_alloc, std::system_error.
-void read_env_file(const char *env_file_path, bool log_warnings, environment &env)
+void read_env_file(const char *env_file_path, bool log_warnings, environment &env, bool throw_on_open_failure)
 {
     std::ifstream env_file(env_file_path);
-    if (! env_file) return;
+    if (!env_file) {
+        if (throw_on_open_failure) {
+            throw std::system_error(errno, std::generic_category());
+        }
+        return;
+    }
 
     env_file.exceptions(std::ios::badbit);
 

--- a/src/dinit.cc
+++ b/src/dinit.cc
@@ -591,7 +591,7 @@ int dinit_main(int argc, char **argv)
     if (!am_system_init || log_specified) setup_external_log();
 
     if (env_file != nullptr) {
-        read_env_file(env_file, true, main_env);
+        read_env_file(env_file, true, main_env, false);
     }
 
     for (auto svc : services_to_start) {

--- a/src/includes/dinit-env.h
+++ b/src/includes/dinit-env.h
@@ -13,8 +13,9 @@ extern environment main_env;
 // Read an environment file and set variables in the current environment.
 //   file - the file to read
 //   log_warnings - if true, syntactic errors are logged
+//   throw_on_open_failure - if true, failure to open file will result in a std::system_error exception
 // May throw bad_alloc or system_error.
-void read_env_file(const char *file, bool log_warnings, environment &env);
+void read_env_file(const char *file, bool log_warnings, environment &env, bool throw_on_open_failure);
 
 // Note that our sets (defined as part of environment class below) allow searching based on a name
 // only (string_view) or "NAME=VALUE" assignment pair (std::string). It is important to always

--- a/src/load-service.cc
+++ b/src/load-service.cc
@@ -539,7 +539,7 @@ service_record * dirload_service_set::load_reload_service(const char *name, serv
 
         if (!settings.env_file.empty()) {
             try {
-                read_env_file(settings.env_file.data(), false, srv_env);
+                read_env_file(settings.env_file.data(), false, srv_env, true);
             } catch (const std::system_error &se) {
                 throw service_load_exc(name, std::string("could not load environment file: ") + se.what());
             }


### PR DESCRIPTION
Try to make less confusion on failure cases like #238  

It makes more sense. Note failure in reading `/etc/dinit/environment` isn't a hard error.