### PR TITLE
Unify socket datatypes

### DIFF
--- a/src/control.cc
+++ b/src/control.cc
@@ -6,6 +6,7 @@
 #include "control.h"
 #include "service.h"
 #include "proc-service.h"
+#include "control-datatypes.h"
 
 // Server-side control protocol implementation. This implements the functionality that allows
 // clients (such as dinitctl) to query service state and issue commands to control services.
@@ -14,6 +15,9 @@
 // 1 - dinit 0.16 and prior
 // 2 - dinit 0.17 (adds DINIT_CP_SETTRIGGER, DINIT_CP_CATLOG, DINIT_CP_SIGNAL)
 // 3 - (unreleased) (adds DINIT_CP_QUERYSERVICEDSCDIR)
+
+// common communication datatypes
+using namespace dinit_ctypes;
 
 namespace {
     // Control protocol minimum compatible version and current version:
@@ -1152,7 +1156,7 @@ bool control_conn_t::query_load_mech()
     }
 }
 
-control_conn_t::handle_t control_conn_t::allocate_service_handle(service_record *record)
+handle_t control_conn_t::allocate_service_handle(service_record *record)
 {
     // Try to find a unique handle (integer) in a single pass. Since the map is ordered, we can search until
     // we find a gap in the handle values.

--- a/src/control.cc
+++ b/src/control.cc
@@ -928,7 +928,7 @@ bool control_conn_t::process_set_trigger()
     }
 
     handle_t handle;
-    char trigger_val;
+    trigger_val_t trigger_val;
 
     rbuf.extract(&handle, 1, sizeof(handle));
     rbuf.extract(&trigger_val, 1 + sizeof(handle), sizeof(trigger_val));

--- a/src/control.cc
+++ b/src/control.cc
@@ -1008,10 +1008,10 @@ bool control_conn_t::process_signal()
         return true;
     }
 
-    int sig_num;
-    rbuf.extract((char *) &sig_num, 1, sizeof(sig_num));
+    sig_num_t sig_num;
+    rbuf.extract(&sig_num, 1, sizeof(sig_num));
     handle_t handle;
-    rbuf.extract((char *) &handle, 1 + sizeof(sig_num), sizeof(handle));
+    rbuf.extract(&handle, 1 + sizeof(sig_num), sizeof(handle));
     rbuf.consume(pkt_size);
     chklen = 0;
 

--- a/src/control.cc
+++ b/src/control.cc
@@ -882,19 +882,19 @@ bool control_conn_t::process_setenv()
         return true;
     }
 
-    uint16_t envSize;
-    rbuf.extract((char *)&envSize, 1, 2);
-    if (envSize <= 0 || envSize > (1024 - 3)) {
+    envvar_len_t envvar_len;
+    rbuf.extract(&envvar_len, 1, sizeof(envvar_len));
+    if (envvar_len <= 0 || envvar_len > (1024 - 3)) {
         goto badreq;
     }
-    chklen = envSize + 3; // packet type + (2 byte) length + envvar
+    chklen = envvar_len + 1 + sizeof(envvar_len); // packet type + (2 byte) length + envvar
 
     if (rbuf.get_length() < chklen) {
         // packet not complete yet; read more
         return true;
     }
 
-    envVar = rbuf.extract_string(3, envSize);
+    envVar = rbuf.extract_string(3, envvar_len);
 
     eq = envVar.find('=');
     if (!eq || eq == envVar.npos) {

--- a/src/dinit-monitor.cc
+++ b/src/dinit-monitor.cc
@@ -362,15 +362,15 @@ static std::vector<stringview> split_command(const char *cmd)
 static int issue_load_service(int socknum, const char *service_name, bool find_only = false)
 {
     // Build buffer;
-    uint16_t sname_len = strlen(service_name);
-    int bufsize = 3 + sname_len;
+    srvname_len_t srvname_len = strlen(service_name);
+    int bufsize = 3 + srvname_len;
 
     std::unique_ptr<char[]> ubuf(new char[bufsize]);
     auto buf = ubuf.get();
 
     buf[0] = (char)(find_only ? cp_cmd::FINDSERVICE : cp_cmd::LOADSERVICE);
-    memcpy(buf + 1, &sname_len, 2);
-    memcpy(buf + 3, service_name, sname_len);
+    memcpy(buf + 1, &srvname_len, sizeof(srvname_len));
+    memcpy(buf + 3, service_name, srvname_len);
 
     write_all_x(socknum, buf, bufsize);
 

--- a/src/dinit-monitor.cc
+++ b/src/dinit-monitor.cc
@@ -19,7 +19,7 @@
 // dinit-monitor: watch service states and report them via execution of a notification command
 
 // common communication datatypes
-using namespace dinit_ctypes;
+using namespace dinit_cptypes;
 
 static constexpr uint16_t min_cp_version = 1;
 static constexpr uint16_t max_cp_version = 1;
@@ -357,7 +357,7 @@ static std::vector<stringview> split_command(const char *cmd)
     return result;
 }
 
-// Issue a "load service" command (DINIT_CP_LOADSERVICE), without waiting for
+// Issue a "load service" command (LOADSERVICE), without waiting for
 // a response. Returns 1 on failure (with error logged), 0 on success.
 static int issue_load_service(int socknum, const char *service_name, bool find_only = false)
 {
@@ -368,7 +368,7 @@ static int issue_load_service(int socknum, const char *service_name, bool find_o
     std::unique_ptr<char[]> ubuf(new char[bufsize]);
     auto buf = ubuf.get();
 
-    buf[0] = find_only ? DINIT_CP_FINDSERVICE : DINIT_CP_LOADSERVICE;
+    buf[0] = (char)(find_only ? cp_cmd::FINDSERVICE : cp_cmd::LOADSERVICE);
     memcpy(buf + 1, &sname_len, 2);
     memcpy(buf + 3, service_name, sname_len);
 

--- a/src/dinit-monitor.cc
+++ b/src/dinit-monitor.cc
@@ -170,7 +170,7 @@ int dinit_monitor_main(int argc, char **argv)
                 int pktlen = (unsigned char) rbuffer[1];
                 fill_buffer_to(rbuffer, socknum, pktlen);
 
-                if (rbuffer[0] == DINIT_IP_SERVICEEVENT) {
+                if (rbuffer[0] == (char)cp_info::SERVICEEVENT) {
                     handle_t ev_handle;
                     rbuffer.extract((char *) &ev_handle, 2, sizeof(ev_handle));
                     service_event_t event = static_cast<service_event_t>(rbuffer[2 + sizeof(ev_handle)]);
@@ -383,7 +383,8 @@ static int check_load_reply(int socknum, cpbuffer_t &rbuffer, handle_t *handle_p
 {
     using namespace std;
 
-    if (rbuffer[0] == DINIT_RP_SERVICERECORD) {
+    cp_rply reply_pkt_h = (cp_rply)rbuffer[0];
+    if (reply_pkt_h == cp_rply::SERVICERECORD) {
         fill_buffer_to(rbuffer, socknum, 2 + sizeof(*handle_p));
         rbuffer.extract((char *) handle_p, 2, sizeof(*handle_p));
         if (state_p) *state_p = static_cast<service_state_t>(rbuffer[1]);
@@ -391,7 +392,7 @@ static int check_load_reply(int socknum, cpbuffer_t &rbuffer, handle_t *handle_p
         rbuffer.consume(3 + sizeof(*handle_p));
         return 0;
     }
-    else if (rbuffer[0] == DINIT_RP_NOSERVICE) {
+    else if (reply_pkt_h == cp_rply::NOSERVICE) {
         return 1;
     }
     else {

--- a/src/dinit-monitor.cc
+++ b/src/dinit-monitor.cc
@@ -14,8 +14,12 @@
 
 #include "dinit-client.h"
 #include "service-constants.h"
+#include "control-datatypes.h"
 
 // dinit-monitor: watch service states and report them via execution of a notification command
+
+// common communication datatypes
+using namespace dinit_ctypes;
 
 static constexpr uint16_t min_cp_version = 1;
 static constexpr uint16_t max_cp_version = 1;

--- a/src/dinitctl.cc
+++ b/src/dinitctl.cc
@@ -1036,15 +1036,15 @@ static int start_stop_service(int socknum, cpbuffer_t &rbuffer, const char *serv
 static int issue_load_service(int socknum, const char *service_name, bool find_only)
 {
     // Build buffer;
-    uint16_t sname_len = strlen(service_name);
-    int bufsize = 3 + sname_len;
+    srvname_len_t srvname_len = strlen(service_name);
+    int bufsize = 3 + srvname_len;
     
     std::unique_ptr<char[]> ubuf(new char[bufsize]);
     auto buf = ubuf.get();
 
     buf[0] = (char)(find_only ? cp_cmd::FINDSERVICE : cp_cmd::LOADSERVICE);
-    memcpy(buf + 1, &sname_len, 2);
-    memcpy(buf + 3, service_name, sname_len);
+    memcpy(buf + 1, &srvname_len, sizeof(srvname_len));
+    memcpy(buf + 3, service_name, srvname_len);
 
     write_all_x(socknum, buf, bufsize);
     

--- a/src/dinitctl.cc
+++ b/src/dinitctl.cc
@@ -58,7 +58,7 @@ static int enable_disable_service(int socknum, cpbuffer_t &rbuffer, service_dir_
 static int do_setenv(int socknum, cpbuffer_t &rbuffer, std::vector<const char *> &env_names);
 static int trigger_service(int socknum, cpbuffer_t &rbuffer, const char *service_name, bool trigger_value);
 static int cat_service_log(int socknum, cpbuffer_t &rbuffer, const char *service_name, bool do_clear);
-static int signal_send(int socknum, cpbuffer_t &rbuffer, const char *service_name, int sig_num);
+static int signal_send(int socknum, cpbuffer_t &rbuffer, const char *service_name, sig_num_t sig_num);
 static int signal_list();
 
 enum class ctl_cmd {
@@ -125,7 +125,7 @@ int dinitctl_main(int argc, char **argv)
     bool use_passed_cfd = false;
     bool show_siglist = false;
     std::string sigstr;
-    int sig_num = -1;
+    sig_num_t sig_num = -1;
 
     for (int i = 1; i < argc; i++) {
         if (argv[i][0] == '-') {
@@ -2098,7 +2098,7 @@ static int trigger_service(int socknum, cpbuffer_t &rbuffer, const char *service
     return 0;
 }
 
-static int signal_send(int socknum, cpbuffer_t &rbuffer, const char *service_name, int sig_num)
+static int signal_send(int socknum, cpbuffer_t &rbuffer, const char *service_name, sig_num_t sig_num)
 {
     using namespace std;
 

--- a/src/dinitctl.cc
+++ b/src/dinitctl.cc
@@ -25,11 +25,15 @@
 #include "dinit-util.h"
 #include "options-processing.h"
 #include "mconfig.h"
+#include "control-datatypes.h"
 
 // dinitctl:  utility to control the Dinit daemon, including starting and stopping of services.
 
 // This utility communicates with the dinit daemon via a unix stream socket (as specified in
 // SYSCONTROLSOCKET, or $HOME/.dinitctl).
+
+// common communication datatypes
+using namespace dinit_ctypes;
 
 static constexpr uint16_t min_cp_version = 1;
 static constexpr uint16_t max_cp_version = 1;

--- a/src/dinitctl.cc
+++ b/src/dinitctl.cc
@@ -2076,7 +2076,7 @@ static int trigger_service(int socknum, cpbuffer_t &rbuffer, const char *service
         auto m = membuf()
                 .append<char>(DINIT_CP_SETTRIGGER)
                 .append(handle)
-                .append<char>(trigger_value);
+                .append<trigger_val_t>(trigger_value);
         write_all_x(socknum, m);
 
         wait_for_reply(rbuffer, socknum);

--- a/src/includes/control-cmds.h
+++ b/src/includes/control-cmds.h
@@ -6,8 +6,6 @@
 // Dinit control command packet types
 
 // Requests:
-
-
 enum class cp_cmd :dinit_cptypes::cp_cmd_t {
     // Query protocol version:
     QUERYVERSION = 0,
@@ -73,81 +71,82 @@ enum class cp_cmd :dinit_cptypes::cp_cmd_t {
 };
 
 // Replies:
+enum class cp_rply :dinit_cptypes::cp_rply_t {
+    // Reply: ACK/NAK to request
+    ACK = 50,
+    NAK = 51,
 
-// Reply: ACK/NAK to request
-constexpr static int DINIT_RP_ACK = 50;
-constexpr static int DINIT_RP_NAK = 51;
+    // Request was bad (connection will be closed)
+    BADREQ = 52,
 
-// Request was bad (connection will be closed)
-constexpr static int DINIT_RP_BADREQ = 52;
+    // Connection being closed due to out-of-memory condition
+    OOM = 53,
 
-// Connection being closed due to out-of-memory condition
-constexpr static int DINIT_RP_OOM = 53;
+    // Start service replies:
+    SERVICELOADERR = 54,
+    SERVICEOOM = 55, // couldn't start due to out-of-memory
 
-// Start service replies:
-constexpr static int DINIT_RP_SERVICELOADERR = 54;
-constexpr static int DINIT_RP_SERVICEOOM = 55; // couldn't start due to out-of-memory
+    // Not (any longer?) used
+    //SSISSUED = 56,  // service start/stop was issued (includes 4-byte service handle)
+    //SSREDUNDANT = 57,  // service was already started/stopped (or for stop, not loaded)
 
-// Not (any longer?) used
-//constexpr static int DINIT_RP_SSISSUED = 56;  // service start/stop was issued (includes 4-byte service handle)
-//constexpr static int DINIT_RP_SSREDUNDANT = 57;  // service was already started/stopped (or for stop, not loaded)
+    // Query version response:
+    CPVERSION = 58,
 
-// Query version response:
-constexpr static int DINIT_RP_CPVERSION = 58;
+    // Service record loaded/found
+    SERVICERECORD = 59,
+    //     followed by 4-byte service handle, 1-byte service state
 
-// Service record loaded/found
-constexpr static int DINIT_RP_SERVICERECORD = 59;
-//     followed by 4-byte service handle, 1-byte service state
+    // Couldn't find/load service
+    NOSERVICE = 60,
 
-// Couldn't find/load service
-constexpr static int DINIT_RP_NOSERVICE = 60;
+    // Service is already started/stopped
+    ALREADYSS = 61,
 
-// Service is already started/stopped
-constexpr static int DINIT_RP_ALREADYSS = 61;
+    // Information on a service / list complete:
+    SVCINFO = 62,
+    LISTDONE = 63,
 
-// Information on a service / list complete:
-constexpr static int DINIT_RP_SVCINFO = 62;
-constexpr static int DINIT_RP_LISTDONE = 63;
+    // Service loader information:
+    LOADER_MECH = 64,
 
-// Service loader information:
-constexpr static int DINIT_RP_LOADER_MECH = 64;
+    // Dependent services prevent stopping/restarting. Includes size_t count, handle_t * N handles.
+    DEPENDENTS = 65,
 
-// Dependent services prevent stopping/restarting. Includes size_t count, handle_t * N handles.
-constexpr static int DINIT_RP_DEPENDENTS = 65;
+    // Service name:
+    SERVICENAME = 66,
 
-// Service name:
-constexpr static int DINIT_RP_SERVICENAME = 66;
+    // Service is pinned stopped/started:
+    PINNEDSTOPPED = 67,
+    PINNEDSTARTED = 68,
 
-// Service is pinned stopped/started:
-constexpr static int DINIT_RP_PINNEDSTOPPED = 67;
-constexpr static int DINIT_RP_PINNEDSTARTED = 68;
+    // Shutdown is in progress, can't start/restart/wake service:
+    SHUTTINGDOWN = 69,
 
-// Shutdown is in progress, can't start/restart/wake service:
-constexpr static int DINIT_RP_SHUTTINGDOWN = 69;
+    // Service status:
+    SERVICESTATUS = 70,
 
-// Service status:
-constexpr static int DINIT_RP_SERVICESTATUS = 70;
+    // Service description error:
+    SERVICE_DESC_ERR = 71,
+    // Service load error (general):
+    SERVICE_LOAD_ERR = 72,
 
-// Service description error:
-constexpr static int DINIT_RP_SERVICE_DESC_ERR = 71;
-// Service load error (general):
-constexpr static int DINIT_RP_SERVICE_LOAD_ERR = 72;
+    // Service log:
+    SERVICE_LOG = 73,
 
-// Service log:
-constexpr static int DINIT_RP_SERVICE_LOG = 73;
+    // Signal replies:
+    SIGNAL_NOPID = 74,
+    SIGNAL_BADSIG = 75,
+    SIGNAL_KILLERR = 76,
 
-// Signal replies:
-constexpr static int DINIT_RP_SIGNAL_NOPID = 74;
-constexpr static int DINIT_RP_SIGNAL_BADSIG = 75;
-constexpr static int DINIT_RP_SIGNAL_KILLERR = 76;
-
-// Service description directory:
-constexpr static int DINIT_RP_SVCDSCDIR = 77;
-
+    // Service description directory:
+    SVCDSCDIR = 77,
+};
 
 // Information (out-of-band):
-
-// Service event occurred (4-byte service handle, 1 byte event code)
-constexpr static int DINIT_IP_SERVICEEVENT = 100;
+enum class cp_info :dinit_cptypes::cp_info_t {
+    // Service event occurred (4-byte service handle, 1 byte event code)
+    SERVICEEVENT = 100,
+};
 
 #endif

--- a/src/includes/control-cmds.h
+++ b/src/includes/control-cmds.h
@@ -6,7 +6,7 @@
 // Dinit control command packet types
 
 // Requests:
-enum class cp_cmd :dinit_cptypes::cp_cmd_t {
+enum class cp_cmd : dinit_cptypes::cp_cmd_t {
     // Query protocol version:
     QUERYVERSION = 0,
 
@@ -71,7 +71,7 @@ enum class cp_cmd :dinit_cptypes::cp_cmd_t {
 };
 
 // Replies:
-enum class cp_rply :dinit_cptypes::cp_rply_t {
+enum class cp_rply : dinit_cptypes::cp_rply_t {
     // Reply: ACK/NAK to request
     ACK = 50,
     NAK = 51,
@@ -144,7 +144,7 @@ enum class cp_rply :dinit_cptypes::cp_rply_t {
 };
 
 // Information (out-of-band):
-enum class cp_info :dinit_cptypes::cp_info_t {
+enum class cp_info : dinit_cptypes::cp_info_t {
     // Service event occurred (4-byte service handle, 1 byte event code)
     SERVICEEVENT = 100,
 };

--- a/src/includes/control-cmds.h
+++ b/src/includes/control-cmds.h
@@ -1,71 +1,76 @@
 #ifndef DINIT_CONTROL_CMDS_H_INCLUDED
 #define DINIT_CONTROL_CMDS_H_INCLUDED 1
 
+#include <control-datatypes.h>
+
 // Dinit control command packet types
 
 // Requests:
 
-// Query protocol version:
-constexpr static int DINIT_CP_QUERYVERSION = 0;
 
-// Find (but don't load) a service:
-constexpr static int DINIT_CP_FINDSERVICE = 1;
+enum class cp_cmd :dinit_cptypes::cp_cmd_t {
+    // Query protocol version:
+    QUERYVERSION = 0,
 
-// Find or load a service:
-constexpr static int DINIT_CP_LOADSERVICE = 2;
+    // Find (but don't load) a service:
+    FINDSERVICE = 1,
 
-// Start or stop a service:
-constexpr static int DINIT_CP_STARTSERVICE = 3;
-constexpr static int DINIT_CP_STOPSERVICE  = 4;
-constexpr static int DINIT_CP_WAKESERVICE = 5;
-constexpr static int DINIT_CP_RELEASESERVICE = 6;
+    // Find or load a service:
+    LOADSERVICE = 2,
 
-constexpr static int DINIT_CP_UNPINSERVICE = 7;
+    // Start or stop a service:
+    STARTSERVICE = 3,
+    STOPSERVICE  = 4,
+    WAKESERVICE = 5,
+    RELEASESERVICE = 6,
 
-// List services:
-constexpr static int DINIT_CP_LISTSERVICES = 8;
+    UNPINSERVICE = 7,
 
-// Unload a service:
-constexpr static int DINIT_CP_UNLOADSERVICE = 9;
+    // List services:
+    LISTSERVICES = 8,
 
-// Shutdown:
-constexpr static int DINIT_CP_SHUTDOWN = 10;
- // followed by 1-byte shutdown type
+    // Unload a service:
+    UNLOADSERVICE = 9,
 
-// Add/remove dependency to existing service:
-constexpr static int DINIT_CP_ADD_DEP = 11;
-constexpr static int DINIT_CP_REM_DEP = 12;
+    // Shutdown:
+    SHUTDOWN = 10,
+     // followed by 1-byte shutdown type
 
-// Query service load path / mechanism:
-constexpr static int DINIT_CP_QUERY_LOAD_MECH = 13;
+    // Add/remove dependency to existing service:
+    ADD_DEP = 11,
+    REM_DEP = 12,
 
-// Add a waits for dependency from one service to another, and start the dependency:
-constexpr static int DINIT_CP_ENABLESERVICE = 14;
+    // Query service load path / mechanism:
+    QUERY_LOAD_MECH = 13,
 
-// Find the name of a service (from a handle)
-constexpr static int DINIT_CP_QUERYSERVICENAME = 15;
+    // Add a waits for dependency from one service to another, and start the dependency:
+    ENABLESERVICE = 14,
 
-// Reload a service:
-constexpr static int DINIT_CP_RELOADSERVICE = 16;
+    // Find the name of a service (from a handle)
+    QUERYSERVICENAME = 15,
 
-// Export a set of environment variables into activation environment:
-constexpr static int DINIT_CP_SETENV = 17;
+    // Reload a service:
+    RELOADSERVICE = 16,
 
-// Query status of an individual service
-constexpr static int DINIT_CP_SERVICESTATUS = 18;
+    // Export a set of environment variables into activation environment:
+    SETENV = 17,
 
-// Set trigger value for triggered services
-constexpr static int DINIT_CP_SETTRIGGER = 19;
+    // Query status of an individual service
+    SERVICESTATUS = 18,
 
-// Retrieve buffered output
-constexpr static int DINIT_CP_CATLOG = 20;
+    // Set trigger value for triggered services
+    SETTRIGGER = 19,
 
-// Send Signal to process
-constexpr static int DINIT_CP_SIGNAL = 21;
+    // Retrieve buffered output
+    CATLOG = 20,
 
-// Query service description directory
-constexpr static int DINIT_CP_QUERYSERVICEDSCDIR = 22;
+    // Send Signal to process
+    SIGNAL = 21,
 
+    // Query service description directory
+    QUERYSERVICEDSCDIR = 22,
+
+};
 
 // Replies:
 

--- a/src/includes/control-datatypes.h
+++ b/src/includes/control-datatypes.h
@@ -13,6 +13,7 @@ namespace dinit_cptypes {
     using cp_info_t = uint8_t;
     using srvname_len_t = uint16_t;
     using envvar_len_t = uint16_t;
+    using sig_num_t = int;
 } // namespace dinit_cptypes
 
 #endif

--- a/src/includes/control-datatypes.h
+++ b/src/includes/control-datatypes.h
@@ -12,6 +12,7 @@ namespace dinit_cptypes {
     using cp_rply_t = uint8_t;
     using cp_info_t = uint8_t;
     using srvname_len_t = uint16_t;
+    using envvar_len_t = uint16_t;
 } // namespace dinit_cptypes
 
 #endif

--- a/src/includes/control-datatypes.h
+++ b/src/includes/control-datatypes.h
@@ -3,13 +3,12 @@
 
 #include <cstdint>
 
-namespace dinit_ctypes {
-
-// A mapping between service records and their associated numerical identifier
-// used in communction
-using handle_t = uint32_t;
-using trigger_val_t = uint8_t;
-
-} // namespace dinit_ctypes
+namespace dinit_cptypes {
+    // A mapping between service records and their associated numerical identifier
+    // used in communction
+    using handle_t = uint32_t;
+    using trigger_val_t = uint8_t;
+    using cp_cmd_t = uint8_t;
+} // namespace dinit_cptypes
 
 #endif

--- a/src/includes/control-datatypes.h
+++ b/src/includes/control-datatypes.h
@@ -9,6 +9,8 @@ namespace dinit_cptypes {
     using handle_t = uint32_t;
     using trigger_val_t = uint8_t;
     using cp_cmd_t = uint8_t;
+    using cp_rply_t = uint8_t;
+    using cp_info_t = uint8_t;
 } // namespace dinit_cptypes
 
 #endif

--- a/src/includes/control-datatypes.h
+++ b/src/includes/control-datatypes.h
@@ -11,6 +11,7 @@ namespace dinit_cptypes {
     using cp_cmd_t = uint8_t;
     using cp_rply_t = uint8_t;
     using cp_info_t = uint8_t;
+    using srvname_len_t = uint16_t;
 } // namespace dinit_cptypes
 
 #endif

--- a/src/includes/control-datatypes.h
+++ b/src/includes/control-datatypes.h
@@ -14,6 +14,7 @@ namespace dinit_cptypes {
     using srvname_len_t = uint16_t;
     using envvar_len_t = uint16_t;
     using sig_num_t = int;
+    using srvstate_t = uint8_t;
 } // namespace dinit_cptypes
 
 #endif

--- a/src/includes/control-datatypes.h
+++ b/src/includes/control-datatypes.h
@@ -1,0 +1,14 @@
+#ifndef DINIT_CONTROL_DATATYPES_H
+#define DINIT_CONTROL_DATATYPES_H
+
+#include <cstdint>
+
+namespace dinit_ctypes {
+
+// A mapping between service records and their associated numerical identifier
+// used in communction
+using handle_t = uint32_t;
+
+} // namespace dinit_ctypes
+
+#endif

--- a/src/includes/control-datatypes.h
+++ b/src/includes/control-datatypes.h
@@ -8,6 +8,7 @@ namespace dinit_ctypes {
 // A mapping between service records and their associated numerical identifier
 // used in communction
 using handle_t = uint32_t;
+using trigger_val_t = uint8_t;
 
 } // namespace dinit_ctypes
 

--- a/src/includes/control.h
+++ b/src/includes/control.h
@@ -104,8 +104,8 @@ class control_conn_t : private service_listener
     template <typename T> using list = std::list<T>;
     template <typename T> using vector = std::vector<T>;
     
-    std::unordered_multimap<service_record *, dinit_ctypes::handle_t> service_key_map;
-    std::map<dinit_ctypes::handle_t, service_record *> key_service_map;
+    std::unordered_multimap<service_record *, dinit_cptypes::handle_t> service_key_map;
+    std::map<dinit_cptypes::handle_t, service_record *> key_service_map;
     
     // Buffer for outgoing packets. Each outgoing packet is represented as a vector<char>.
     list<vector<char>> outbuf;
@@ -135,10 +135,10 @@ class control_conn_t : private service_listener
     bool process_packet();
     
     // Process a STARTSERVICE/STOPSERVICE packet. May throw std::bad_alloc.
-    bool process_start_stop(int pktType);
+    bool process_start_stop(cp_cmd pktType);
     
     // Process a FINDSERVICE/LOADSERVICE packet. May throw std::bad_alloc.
-    bool process_find_load(int pktType);
+    bool process_find_load(cp_cmd pktType);
 
     // Process an UNPINSERVICE packet. May throw std::bad_alloc.
     bool process_unpin_service();
@@ -194,10 +194,10 @@ class control_conn_t : private service_listener
     bool check_dependents(service_record *service, bool &had_dependents);
 
     // Allocate a new handle for a service; may throw std::bad_alloc
-    dinit_ctypes::handle_t allocate_service_handle(service_record *record);
+    dinit_cptypes::handle_t allocate_service_handle(service_record *record);
     
     // Find the service corresponding to a service handle; returns nullptr if not found.
-    service_record *find_service_for_key(dinit_ctypes::handle_t key) noexcept
+    service_record *find_service_for_key(dinit_cptypes::handle_t key) noexcept
     {
         try {
             return key_service_map.at(key);

--- a/src/includes/control.h
+++ b/src/includes/control.h
@@ -15,6 +15,7 @@
 #include <control-cmds.h>
 #include <service-listener.h>
 #include <cpbuffer.h>
+#include <control-datatypes.h>
 
 // Control connection for dinit
 
@@ -84,11 +85,6 @@ class control_conn_t : private service_listener
 {
     friend rearm control_conn_cb(eventloop_t *loop, control_conn_watcher *watcher, int revents);
     friend class control_conn_t_test;
-    
-    public:
-    // A mapping between service records and their associated numerical identifier used
-    // in communction
-    using handle_t = uint32_t;
 
     private:
     control_conn_watcher iob;
@@ -108,8 +104,8 @@ class control_conn_t : private service_listener
     template <typename T> using list = std::list<T>;
     template <typename T> using vector = std::vector<T>;
     
-    std::unordered_multimap<service_record *, handle_t> service_key_map;
-    std::map<handle_t, service_record *> key_service_map;
+    std::unordered_multimap<service_record *, dinit_ctypes::handle_t> service_key_map;
+    std::map<dinit_ctypes::handle_t, service_record *> key_service_map;
     
     // Buffer for outgoing packets. Each outgoing packet is represented as a vector<char>.
     list<vector<char>> outbuf;
@@ -198,10 +194,10 @@ class control_conn_t : private service_listener
     bool check_dependents(service_record *service, bool &had_dependents);
 
     // Allocate a new handle for a service; may throw std::bad_alloc
-    handle_t allocate_service_handle(service_record *record);
+    dinit_ctypes::handle_t allocate_service_handle(service_record *record);
     
     // Find the service corresponding to a service handle; returns nullptr if not found.
-    service_record *find_service_for_key(handle_t key) noexcept
+    service_record *find_service_for_key(dinit_ctypes::handle_t key) noexcept
     {
         try {
             return key_service_map.at(key);

--- a/src/includes/dinit-client.h
+++ b/src/includes/dinit-client.h
@@ -8,6 +8,8 @@
 #include <cpbuffer.h>
 #include <control-cmds.h>
 
+#include <control-datatypes.h>
+
 // Client library for Dinit clients
 
 using cpbuffer_t = cpbuffer<1024>;
@@ -236,7 +238,7 @@ template <typename Buf> inline void write_all_x(int fd, const Buf &b)
 inline uint16_t check_protocol_version(int minversion, int version, cpbuffer_t &rbuffer, int fd)
 {
     constexpr int bufsize = 1;
-    char buf[bufsize] = { DINIT_CP_QUERYVERSION };
+    char buf[bufsize] = { (char)cp_cmd::QUERYVERSION };
     write_all_x(fd, buf, bufsize);
 
     wait_for_reply(rbuffer, fd);

--- a/src/includes/dinit-client.h
+++ b/src/includes/dinit-client.h
@@ -237,16 +237,17 @@ template <typename Buf> inline void write_all_x(int fd, const Buf &b)
 // throws an exception on protocol mismatch or error.
 inline uint16_t check_protocol_version(int minversion, int version, cpbuffer_t &rbuffer, int fd)
 {
+    using namespace dinit_cptypes;
     constexpr int bufsize = 1;
     char buf[bufsize] = { (char)cp_cmd::QUERYVERSION };
     write_all_x(fd, buf, bufsize);
 
     wait_for_reply(rbuffer, fd);
-    if (rbuffer[0] != DINIT_RP_CPVERSION) {
+    if (rbuffer[0] != (char)cp_rply::CPVERSION) {
         throw cp_read_exception{0};
     }
 
-    // DINIT_RP_CVERSION, (2 byte) minimum compatible version, (2 byte) actual version
+    // cp_rply::CVERSION, (2 byte) minimum compatible version, (2 byte) actual version
     constexpr int rbufsize = 1 + 2 * sizeof(uint16_t);
     fill_buffer_to(rbuffer, fd, rbufsize);
     uint16_t rminversion;

--- a/src/includes/dinit-client.h
+++ b/src/includes/dinit-client.h
@@ -10,8 +10,6 @@
 
 // Client library for Dinit clients
 
-
-using handle_t = uint32_t;
 using cpbuffer_t = cpbuffer<1024>;
 
 class cp_read_exception

--- a/src/includes/service-constants.h
+++ b/src/includes/service-constants.h
@@ -6,7 +6,7 @@
 #include <control-datatypes.h>
 
 /* Service states */
-enum class service_state_t :dinit_cptypes::srvstate_t {
+enum class service_state_t : dinit_cptypes::srvstate_t {
     STOPPED,    // service is not running.
     STARTING,   // service is starting, and will start (or fail to start) in time.
     STARTED,    // service is running,

--- a/src/includes/service-constants.h
+++ b/src/includes/service-constants.h
@@ -3,8 +3,10 @@
 
 #include <mconfig.h>
 
+#include <control-datatypes.h>
+
 /* Service states */
-enum class service_state_t {
+enum class service_state_t :dinit_cptypes::srvstate_t {
     STOPPED,    // service is not running.
     STARTING,   // service is starting, and will start (or fail to start) in time.
     STARTED,    // service is running,

--- a/src/shutdown.cc
+++ b/src/shutdown.cc
@@ -361,7 +361,7 @@ int main(int argc, char **argv)
     
         wait_for_reply(rbuffer, socknum);
         
-        if (rbuffer[0] != DINIT_RP_ACK) {
+        if (rbuffer[0] != (dinit_cptypes::cp_rply_t)cp_rply::ACK) {
             cerr << "shutdown: control socket protocol error" << endl;
             return 1;
         }

--- a/src/shutdown.cc
+++ b/src/shutdown.cc
@@ -21,6 +21,7 @@
 #include "dinit-client.h"
 #include "dinit-util.h"
 #include "mconfig.h"
+#include "control-datatypes.h"
 
 #include "dasynq.h"
 
@@ -349,7 +350,7 @@ int main(int argc, char **argv)
         constexpr int bufsize = 2;
         char buf[bufsize];
 
-        buf[0] = DINIT_CP_SHUTDOWN;
+        buf[0] = (dinit_cptypes::cp_cmd_t)cp_cmd::SHUTDOWN;
         buf[1] = static_cast<char>(shutdown_type);
 
         cout << "Issuing shutdown command..." << endl;

--- a/src/tests/cptests/cptests.cc
+++ b/src/tests/cptests/cptests.cc
@@ -52,7 +52,7 @@ void cptest_queryver()
     bp_sys::extract_written_data(fd, wdata);
 
     assert(wdata.size() == 5);
-    assert(wdata[0] == DINIT_RP_CPVERSION);
+    assert(wdata[0] == (char)cp_rply::CPVERSION);
 
     delete cc;
 }
@@ -79,7 +79,7 @@ void cptest_listservices()
     //event_loop.regd_bidi_watchers[fd]->write_ready(event_loop, fd);
 
     // We expect, for each service:
-    // (1 byte)   DINIT_RP_SVCINFO
+    // (1 byte)   cp_rply::SVCINFO
     // (1 byte)   service name length
     // (1 byte)   state
     // (1 byte)   target state
@@ -96,7 +96,7 @@ void cptest_listservices()
 
     int pos = 0;
     for (int i = 0; i < 3; i++) {
-        assert(wdata[pos++] == DINIT_RP_SVCINFO);
+        assert(wdata[pos++] == (char)cp_rply::SVCINFO);
         unsigned char name_len_c = wdata[pos++];
         pos += 6;
 
@@ -133,13 +133,13 @@ static handle_t  find_service(int fd, const char *service_name,
     bp_sys::extract_written_data(fd, wdata);
 
     // We expect:
-    // (1 byte)   DINIT_RP_SERVICERECORD
+    // (1 byte)   cp_rply::SERVICERECORD
     // (1 byte)   state
     // (handle_t) handle
     // (1 byte)   target state
 
     assert(wdata.size() == 3 + sizeof(handle_t));
-    assert(wdata[0] == DINIT_RP_SERVICERECORD);
+    assert(wdata[0] == (char)cp_rply::SERVICERECORD);
     service_state_t s = static_cast<service_state_t>(wdata[1]);
     assert(s == expected_state);
     service_state_t ts = static_cast<service_state_t>(wdata[6]);
@@ -227,13 +227,13 @@ void cptest_findservice3()
     event_loop.regd_bidi_watchers[fd]->read_ready(event_loop, fd);
 
     // We expect:
-    // (1 byte)   DINIT_RP_NOSERVICE
+    // (1 byte)   cp_rply::NOSERVICE
 
     std::vector<char> wdata;
     bp_sys::extract_written_data(fd, wdata);
 
     assert(wdata.size() == 1);
-    assert(wdata[0] == DINIT_RP_NOSERVICE);
+    assert(wdata[0] == (char)cp_rply::NOSERVICE);
 
     delete cc;
 }
@@ -286,7 +286,7 @@ void cptest_loadservice()
     event_loop.regd_bidi_watchers[fd]->read_ready(event_loop, fd);
 
     // We expect:
-    // (1 byte)   DINIT_RP_SERVICERECORD
+    // (1 byte)   cp_rply::SERVICERECORD
     // (1 byte)   state
     // (handle_t) handle
     // (1 byte)   target state
@@ -295,7 +295,7 @@ void cptest_loadservice()
     bp_sys::extract_written_data(fd, wdata);
 
     assert(wdata.size() == 3 + sizeof(handle_t));
-    assert(wdata[0] == DINIT_RP_SERVICERECORD);
+    assert(wdata[0] == (char)cp_rply::SERVICERECORD);
     service_state_t s = static_cast<service_state_t>(wdata[1]);
     assert(s == service_state_t::STOPPED);
     service_state_t ts = static_cast<service_state_t>(wdata[6]);
@@ -313,7 +313,7 @@ void cptest_loadservice()
     event_loop.regd_bidi_watchers[fd]->read_ready(event_loop, fd);
 
     // We expect:
-    // (1 byte)   DINIT_RP_SERVICERECORD
+    // (1 byte)   cp_rply::SERVICERECORD
     // (1 byte)   state
     // (handle_t) handle
     // (1 byte)   target state
@@ -321,7 +321,7 @@ void cptest_loadservice()
     bp_sys::extract_written_data(fd, wdata);
 
     assert(wdata.size() == 3 + sizeof(handle_t));
-    assert(wdata[0] == DINIT_RP_SERVICERECORD);
+    assert(wdata[0] == (char)cp_rply::SERVICERECORD);
     s = static_cast<service_state_t>(wdata[1]);
     assert(s == service_state_t::STOPPED);
     ts = static_cast<service_state_t>(wdata[6]);
@@ -361,7 +361,7 @@ void cptest_startstop()
     std::vector<char> wdata;
     bp_sys::extract_written_data(fd, wdata);
     assert(wdata.size() == 1 + 7 + STATUS_BUFFER_SIZE /* ACK reply + info packet */);
-    assert(wdata[0] == DINIT_IP_SERVICEEVENT);
+    assert(wdata[0] == (char)cp_info::SERVICEEVENT);
     // packetsize, key (handle), event
     assert(wdata[1] == 7 + STATUS_BUFFER_SIZE);
     handle_t ip_h;
@@ -371,7 +371,7 @@ void cptest_startstop()
 
     constexpr unsigned reply_start = 7 + STATUS_BUFFER_SIZE;
     // we get ALREADYSS since it started immediately:
-    assert(wdata[reply_start] == DINIT_RP_ALREADYSS);
+    assert(wdata[reply_start] == (char)cp_rply::ALREADYSS);
     assert(s1->get_state() == service_state_t::STARTED);
 
     // Issue stop:
@@ -384,14 +384,14 @@ void cptest_startstop()
 
     bp_sys::extract_written_data(fd, wdata);
     assert(wdata.size() == 1 + 7 + STATUS_BUFFER_SIZE);
-    assert(wdata[0] == DINIT_IP_SERVICEEVENT);
+    assert(wdata[0] == (char)cp_info::SERVICEEVENT);
     // packetsize, key (handle), event
     assert(wdata[1] == 7 + STATUS_BUFFER_SIZE);
     std::copy(wdata.data() + 2, wdata.data() + 2 + sizeof(ip_h), reinterpret_cast<char *>(&ip_h));
     assert(ip_h == h);
     assert(wdata[6] == static_cast<int>(service_event_t::STOPPED));
     // we get ALREADYSS since it stopped immediately:
-    assert(wdata[reply_start] == DINIT_RP_ALREADYSS);
+    assert(wdata[reply_start] == (char)cp_rply::ALREADYSS);
     assert(s1->get_state() == service_state_t::STOPPED);
 
     delete cc;
@@ -426,8 +426,8 @@ void cptest_start_pinned()
 
     std::vector<char> wdata;
     bp_sys::extract_written_data(fd, wdata);
-    assert(wdata.size() == 1 /* DINIT_RP_PINNEDSTOPPED */);
-    assert(wdata[0] == DINIT_RP_PINNEDSTOPPED);
+    assert(wdata.size() == 1 /* cp_rply::PINNEDSTOPPED */);
+    assert(wdata[0] == (char)cp_rply::PINNEDSTOPPED);
 
     delete cc;
 }
@@ -470,12 +470,12 @@ void cptest_gentlestop()
     bp_sys::extract_written_data(fd, wdata);
 
     // We expect:
-    // 1 byte: DINIT_RP_DEPENDENTS
+    // 1 byte: cp_rply::DEPENDENTS
     // size_t: number of handles (N)
     // N * handle_t: handles for dependents that would be stopped
 
     assert(wdata.size() == (1 + sizeof(size_t) + sizeof(handle_t)));
-    assert(wdata[0] == DINIT_RP_DEPENDENTS);
+    assert(wdata[0] == (char)cp_rply::DEPENDENTS);
 
     size_t nhandles;
     memcpy(&nhandles, wdata.data() + 1, sizeof(nhandles));
@@ -520,13 +520,13 @@ void cptest_queryname()
     bp_sys::extract_written_data(fd, wdata);
 
     // We expect:
-    // 1 byte packet type = DINIT_RP_SERVICENAME
+    // 1 byte packet type = cp_rply::SERVICENAME
     // 1 byte reserved
     // uint16_t length
     // N bytes name
 
     assert(wdata.size() == (2 + sizeof(uint16_t) + strlen(test1_name)));
-    assert(wdata[0] == DINIT_RP_SERVICENAME);
+    assert(wdata[0] == (char)cp_rply::SERVICENAME);
     assert(wdata[1] == 0);
     uint16_t len;
     memcpy(&len, wdata.data() + 2, sizeof(uint16_t));
@@ -569,7 +569,7 @@ void cptest_unload()
     std::vector<char> wdata;
     bp_sys::extract_written_data(fd, wdata);
     assert(wdata.size() == 1);
-    assert(wdata[0] == DINIT_RP_NAK);
+    assert(wdata[0] == (char)cp_rply::NAK);
 
 
     handle_t h2 = find_service(fd, service_name2, service_state_t::STOPPED,
@@ -588,7 +588,7 @@ void cptest_unload()
     // We should receive ACK:
     bp_sys::extract_written_data(fd, wdata);
     assert(wdata.size() == 1);
-    assert(wdata[0] == DINIT_RP_ACK);
+    assert(wdata[0] == (char)cp_rply::ACK);
 
     // Now try to unload s1 again:
 
@@ -603,7 +603,7 @@ void cptest_unload()
     // We should receive ACK:
     bp_sys::extract_written_data(fd, wdata);
     assert(wdata.size() == 1);
-    assert(wdata[0] == DINIT_RP_ACK);
+    assert(wdata[0] == (char)cp_rply::ACK);
 
     // If we try to FIND service 1 now, it should not be there:
     cmd = { (char)cp_cmd::FINDSERVICE };
@@ -618,7 +618,7 @@ void cptest_unload()
 
     bp_sys::extract_written_data(fd, wdata);
     assert(wdata.size() == 1);
-    assert(wdata[0] == DINIT_RP_NOSERVICE);
+    assert(wdata[0] == (char)cp_rply::NOSERVICE);
 
     delete cc;
 }
@@ -656,7 +656,7 @@ void cptest_addrmdeps()
     bp_sys::extract_written_data(fd, wdata);
 
     assert(wdata.size() == 1);
-    assert(wdata[0] == DINIT_RP_ACK);
+    assert(wdata[0] == (char)cp_rply::ACK);
 
     // Issue start for S1. S2 should also start:
     cmd = { (char)cp_cmd::STARTSERVICE, 0 /* don't pin */ };
@@ -720,7 +720,7 @@ void cptest_enableservice()
     bp_sys::extract_written_data(fd, wdata);
 
     assert(wdata.size() == 1 + 7 + STATUS_BUFFER_SIZE /* ACK reply + info packet */);
-    assert(wdata[0] == DINIT_IP_SERVICEEVENT);
+    assert(wdata[0] == (char)cp_info::SERVICEEVENT);
     // packetsize, key (handle), event
     assert(wdata[1] == 7 + STATUS_BUFFER_SIZE);
     handle_t ip_h;
@@ -729,7 +729,7 @@ void cptest_enableservice()
     assert(wdata[6] == static_cast<int>(service_event_t::STARTED));
 
     // and then the ack:
-    assert(wdata[7 + STATUS_BUFFER_SIZE] == DINIT_RP_ACK);
+    assert(wdata[7 + STATUS_BUFFER_SIZE] == (char)cp_rply::ACK);
 
     sset.process_queues();
 
@@ -778,7 +778,7 @@ void cptest_restart()
     bp_sys::extract_written_data(fd, wdata);
 
     assert(wdata.size() == 1 /* NAK reply, wrong state */);
-    assert(wdata[0] == DINIT_RP_NAK);
+    assert(wdata[0] == (char)cp_rply::NAK);
 
     // Start the service now:
     s1->start();
@@ -794,13 +794,13 @@ void cptest_restart()
     bp_sys::extract_written_data(fd, wdata);
 
     assert(wdata.size() == 7 + STATUS_BUFFER_SIZE + 1);  // info packet (service stopped) + ACK
-    assert(wdata[0] == DINIT_IP_SERVICEEVENT);
+    assert(wdata[0] == (char)cp_info::SERVICEEVENT);
     assert(wdata[1] == 7 + STATUS_BUFFER_SIZE);
     handle_t ip_h;
     std::copy(wdata.data() + 2, wdata.data() + 2 + sizeof(ip_h), reinterpret_cast<char *>(&ip_h));
     assert(ip_h == h);
     assert(wdata[6] == static_cast<int>(service_event_t::STOPPED));
-    assert(wdata[7 + STATUS_BUFFER_SIZE] == DINIT_RP_ACK);
+    assert(wdata[7 + STATUS_BUFFER_SIZE] == (char)cp_rply::ACK);
 
     sset.process_queues();
     assert(s1->get_state() == service_state_t::STARTING);
@@ -812,7 +812,7 @@ void cptest_restart()
     bp_sys::extract_written_data(fd, wdata);
 
     assert(wdata.size() == 7 + STATUS_BUFFER_SIZE);  /* info packet */
-    assert(wdata[0] == DINIT_IP_SERVICEEVENT);
+    assert(wdata[0] == (char)cp_info::SERVICEEVENT);
     // packetsize, key (handle), event
     assert(wdata[1] == 7 + STATUS_BUFFER_SIZE);
     std::copy(wdata.data() + 2, wdata.data() + 2 + sizeof(ip_h), reinterpret_cast<char *>(&ip_h));
@@ -861,7 +861,7 @@ void cptest_wake()
     bp_sys::extract_written_data(fd, wdata);
 
     assert(wdata.size() == 1 + 7 + STATUS_BUFFER_SIZE /* ACK reply + info packet */);
-    assert(wdata[0] == DINIT_IP_SERVICEEVENT);
+    assert(wdata[0] == (char)cp_info::SERVICEEVENT);
     // packetsize, key (handle), event
     assert(wdata[1] == 7 + STATUS_BUFFER_SIZE);
     handle_t ip_h;
@@ -870,7 +870,7 @@ void cptest_wake()
     assert(wdata[6] == static_cast<int>(service_event_t::STARTED));
 
     // and then the ack (already started):
-    assert(wdata[7 + STATUS_BUFFER_SIZE] == DINIT_RP_ALREADYSS);
+    assert(wdata[7 + STATUS_BUFFER_SIZE] == (char)cp_rply::ALREADYSS);
 
     // now stop s2 (and therefore s1):
     s2->stop(true);
@@ -890,7 +890,7 @@ void cptest_wake()
     bp_sys::extract_written_data(fd, wdata);
 
     assert(wdata.size() == 1);
-    assert(wdata[0] == DINIT_RP_NAK);
+    assert(wdata[0] == (char)cp_rply::NAK);
 
     delete cc;
 }
@@ -930,11 +930,11 @@ void cptest_servicestatus()
 
     constexpr static int STATUS_BUFFER_SIZE = 6 + ((sizeof(pid_t) > sizeof(int)) ? sizeof(pid_t) : sizeof(int));
 
-    // 1 byte: DINIT_RP_SERVICESTATUS
+    // 1 byte: cp_rply::SERVICESTATUS
     // 1 byte: reserved
     // STATUS_BUFFER_SIZE bytes: status
     assert(wdata.size() == (2 + STATUS_BUFFER_SIZE));
-    assert(wdata[0] == DINIT_RP_SERVICESTATUS);
+    assert(wdata[0] == (char)cp_rply::SERVICESTATUS);
     assert(wdata[2] == (int)service_state_t::STOPPED); // state
     assert(wdata[3] == (int)service_state_t::STOPPED); // target state
     assert(wdata[4] == 0); // various flags
@@ -950,7 +950,7 @@ void cptest_servicestatus()
     bp_sys::extract_written_data(fd, wdata);
 
     assert(wdata.size() == (2 + STATUS_BUFFER_SIZE));
-    assert(wdata[0] == DINIT_RP_SERVICESTATUS);
+    assert(wdata[0] == (char)cp_rply::SERVICESTATUS);
     assert(wdata[2] == (int)service_state_t::STARTED); // state
     assert(wdata[3] == (int)service_state_t::STARTED); // target state
     assert(wdata[4] == 8); // various flags; 8 = marked active
@@ -1002,7 +1002,7 @@ void cptest_sendsignal()
     std::vector<char> wdata;
     bp_sys::extract_written_data(fd, wdata);
     assert(wdata.size() == 1);
-    assert(wdata[0] == DINIT_RP_ACK);
+    assert(wdata[0] == (char)cp_rply::ACK);
 
     assert(bp_sys::last_sig_sent == SIGHUP);
 
@@ -1021,7 +1021,7 @@ void cptest_sendsignal()
     wdata.clear();
     bp_sys::extract_written_data(fd, wdata);
     assert(wdata.size() == 1);
-    assert(wdata[0] == DINIT_RP_ACK);
+    assert(wdata[0] == (char)cp_rply::ACK);
 
     assert(bp_sys::last_sig_sent == SIGILL);
 

--- a/src/tests/cptests/cptests.cc
+++ b/src/tests/cptests/cptests.cc
@@ -20,7 +20,7 @@
 #endif
 
 // common communication datatypes
-using namespace dinit_ctypes;
+using namespace dinit_cptypes;
 
 class control_conn_t_test
 {
@@ -40,7 +40,7 @@ void cptest_queryver()
     int fd = bp_sys::allocfd();
     auto *cc = new control_conn_t(event_loop, &sset, fd);
 
-    bp_sys::supply_read_data(fd, { DINIT_CP_QUERYVERSION });
+    bp_sys::supply_read_data(fd, { (char)cp_cmd::QUERYVERSION });
 
     event_loop.regd_bidi_watchers[fd]->read_ready(event_loop, fd);
 
@@ -71,7 +71,7 @@ void cptest_listservices()
     int fd = bp_sys::allocfd();
     auto *cc = new control_conn_t(event_loop, &sset, fd);
 
-    bp_sys::supply_read_data(fd, { DINIT_CP_LISTSERVICES });
+    bp_sys::supply_read_data(fd, { (char)cp_cmd::LISTSERVICES });
 
     event_loop.regd_bidi_watchers[fd]->read_ready(event_loop, fd);
 
@@ -119,7 +119,7 @@ void cptest_listservices()
 static handle_t  find_service(int fd, const char *service_name,
         service_state_t expected_state, service_state_t expected_target_state)
 {
-    std::vector<char> cmd = { DINIT_CP_FINDSERVICE };
+    std::vector<char> cmd = { (char)cp_cmd::FINDSERVICE };
     uint16_t name_len = strlen(service_name);
     char *name_len_cptr = reinterpret_cast<char *>(&name_len);
     cmd.insert(cmd.end(), name_len_cptr, name_len_cptr + sizeof(name_len));
@@ -216,7 +216,7 @@ void cptest_findservice3()
     int fd = bp_sys::allocfd();
     auto *cc = new control_conn_t(event_loop, &sset, fd);
 
-    std::vector<char> cmd = { DINIT_CP_FINDSERVICE };
+    std::vector<char> cmd = { (char)cp_cmd::FINDSERVICE };
     uint16_t name_len = strlen(service_name_2);
     char *name_len_cptr = reinterpret_cast<char *>(&name_len);
     cmd.insert(cmd.end(), name_len_cptr, name_len_cptr + sizeof(name_len));
@@ -274,7 +274,7 @@ void cptest_loadservice()
     int fd = bp_sys::allocfd();
     auto *cc = new control_conn_t(event_loop, &sset, fd);
 
-    std::vector<char> cmd = { DINIT_CP_LOADSERVICE };
+    std::vector<char> cmd = { (char)cp_cmd::LOADSERVICE };
     uint16_t name_len = strlen(service_name_1);
     char *name_len_cptr = reinterpret_cast<char *>(&name_len);
     cmd.insert(cmd.end(), name_len_cptr, name_len_cptr + sizeof(name_len));
@@ -304,7 +304,7 @@ void cptest_loadservice()
     assert(sset.service1 != nullptr);
     assert(sset.service2 == nullptr);
 
-    cmd = { DINIT_CP_LOADSERVICE };
+    cmd = { (char)cp_cmd::LOADSERVICE };
     cmd.insert(cmd.end(), name_len_cptr, name_len_cptr + sizeof(name_len));
     cmd.insert(cmd.end(), service_name_2, service_name_2 + name_len);
 
@@ -350,7 +350,7 @@ void cptest_startstop()
             service_state_t::STOPPED);
 
     // Issue start:
-    std::vector<char> cmd = { DINIT_CP_STARTSERVICE, 0 /* don't pin */ };
+    std::vector<char> cmd = { (char)cp_cmd::STARTSERVICE, 0 /* don't pin */ };
     char * h_cp = reinterpret_cast<char *>(&h);
     cmd.insert(cmd.end(), h_cp, h_cp + sizeof(h));
 
@@ -375,7 +375,7 @@ void cptest_startstop()
     assert(s1->get_state() == service_state_t::STARTED);
 
     // Issue stop:
-    cmd = { DINIT_CP_STOPSERVICE, 0 /* don't pin */ };
+    cmd = { (char)cp_cmd::STOPSERVICE, 0 /* don't pin */ };
     cmd.insert(cmd.end(), h_cp, h_cp + sizeof(h));
 
     bp_sys::supply_read_data(fd, std::move(cmd));
@@ -416,7 +416,7 @@ void cptest_start_pinned()
             service_state_t::STOPPED);
 
     // Issue start:
-    std::vector<char> cmd = { DINIT_CP_STARTSERVICE, 0 /* don't pin */ };
+    std::vector<char> cmd = { (char)cp_cmd::STARTSERVICE, 0 /* don't pin */ };
     char * h_cp = reinterpret_cast<char *>(&h);
     cmd.insert(cmd.end(), h_cp, h_cp + sizeof(h));
 
@@ -459,7 +459,7 @@ void cptest_gentlestop()
     char * h_cp = reinterpret_cast<char *>(&h);
 
     // Issue stop:
-    std::vector<char> cmd = { DINIT_CP_STOPSERVICE, 2 /* don't pin, gentle */ };
+    std::vector<char> cmd = { (char)cp_cmd::STOPSERVICE, 2 /* don't pin, gentle */ };
     cmd.insert(cmd.end(), h_cp, h_cp + sizeof(h));
 
     bp_sys::supply_read_data(fd, std::move(cmd));
@@ -509,7 +509,7 @@ void cptest_queryname()
     char * h_cp = reinterpret_cast<char *>(&h);
 
     // Issue name query:
-    std::vector<char> cmd = { DINIT_CP_QUERYSERVICENAME, 0 /* reserved */ };
+    std::vector<char> cmd = { (char)cp_cmd::QUERYSERVICENAME, 0 /* reserved */ };
     cmd.insert(cmd.end(), h_cp, h_cp + sizeof(h));
 
     bp_sys::supply_read_data(fd, std::move(cmd));
@@ -557,7 +557,7 @@ void cptest_unload()
             service_state_t::STOPPED);
 
     // Issue unload:
-    std::vector<char> cmd = { DINIT_CP_UNLOADSERVICE };
+    std::vector<char> cmd = { (char)cp_cmd::UNLOADSERVICE };
     char * h_cp = reinterpret_cast<char *>(&h1);
     cmd.insert(cmd.end(), h_cp, h_cp + sizeof(h1));
 
@@ -577,7 +577,7 @@ void cptest_unload()
 
     // Issue unload for s2:
 
-    cmd = { DINIT_CP_UNLOADSERVICE };
+    cmd = { (char)cp_cmd::UNLOADSERVICE };
     h_cp = reinterpret_cast<char *>(&h2);
     cmd.insert(cmd.end(), h_cp, h_cp + sizeof(h2));
 
@@ -592,7 +592,7 @@ void cptest_unload()
 
     // Now try to unload s1 again:
 
-    cmd = { DINIT_CP_UNLOADSERVICE };
+    cmd = { (char)cp_cmd::UNLOADSERVICE };
     h_cp = reinterpret_cast<char *>(&h1);
     cmd.insert(cmd.end(), h_cp, h_cp + sizeof(h1));
 
@@ -606,7 +606,7 @@ void cptest_unload()
     assert(wdata[0] == DINIT_RP_ACK);
 
     // If we try to FIND service 1 now, it should not be there:
-    cmd = { DINIT_CP_FINDSERVICE };
+    cmd = { (char)cp_cmd::FINDSERVICE };
     uint16_t name_len = strlen(service_name1);
     char *name_len_cptr = reinterpret_cast<char *>(&name_len);
     cmd.insert(cmd.end(), name_len_cptr, name_len_cptr + sizeof(name_len));
@@ -644,7 +644,7 @@ void cptest_addrmdeps()
             service_state_t::STOPPED);
 
     // Add dep from s1 -> s2:
-    std::vector<char> cmd = { DINIT_CP_ADD_DEP, static_cast<char>(dependency_type::REGULAR) };
+    std::vector<char> cmd = { (char)cp_cmd::ADD_DEP, static_cast<char>(dependency_type::REGULAR) };
     char * h1cp = reinterpret_cast<char *>(&h1);
     char * h2cp = reinterpret_cast<char *>(&h2);
     cmd.insert(cmd.end(), h1cp, h1cp + sizeof(h1));
@@ -659,7 +659,7 @@ void cptest_addrmdeps()
     assert(wdata[0] == DINIT_RP_ACK);
 
     // Issue start for S1. S2 should also start:
-    cmd = { DINIT_CP_STARTSERVICE, 0 /* don't pin */ };
+    cmd = { (char)cp_cmd::STARTSERVICE, 0 /* don't pin */ };
     cmd.insert(cmd.end(), h1cp, h1cp + sizeof(h1));
 
     bp_sys::supply_read_data(fd, std::move(cmd));
@@ -671,7 +671,7 @@ void cptest_addrmdeps()
     assert(s2->get_state() == service_state_t::STARTED);
 
     // Remove dependency from S1 -> S2:
-    cmd = { DINIT_CP_REM_DEP, static_cast<char>(dependency_type::REGULAR) };
+    cmd = { (char)cp_cmd::REM_DEP, static_cast<char>(dependency_type::REGULAR) };
     cmd.insert(cmd.end(), h1cp, h1cp + sizeof(h1));
     cmd.insert(cmd.end(), h2cp, h2cp + sizeof(h2));
 
@@ -707,7 +707,7 @@ void cptest_enableservice()
     handle_t h2 = find_service(fd, service_name2, service_state_t::STOPPED, service_state_t::STOPPED);
 
     // Enable from s1 -> s2:
-    std::vector<char> cmd = { DINIT_CP_ENABLESERVICE, static_cast<char>(dependency_type::WAITS_FOR) };
+    std::vector<char> cmd = { (char)cp_cmd::ENABLESERVICE, static_cast<char>(dependency_type::WAITS_FOR) };
     char * h1cp = reinterpret_cast<char *>(&h1);
     char * h2cp = reinterpret_cast<char *>(&h2);
     cmd.insert(cmd.end(), h1cp, h1cp + sizeof(h1));
@@ -767,7 +767,7 @@ void cptest_restart()
     assert(wdata.size() == 0);
 
     // Issue restart:
-    std::vector<char> cmd = { DINIT_CP_STOPSERVICE, 4 /* restart */ };
+    std::vector<char> cmd = { (char)cp_cmd::STOPSERVICE, 4 /* restart */ };
     char * h_cp = reinterpret_cast<char *>(&h);
     cmd.insert(cmd.end(), h_cp, h_cp + sizeof(h));
 
@@ -851,7 +851,7 @@ void cptest_wake()
             service_state_t::STOPPED);
 
     // Wake s1:
-    std::vector<char> cmd = { DINIT_CP_WAKESERVICE, 0 /* don't pin */ };
+    std::vector<char> cmd = { (char)cp_cmd::WAKESERVICE, 0 /* don't pin */ };
     char * h_cp = reinterpret_cast<char *>(&h1);
     cmd.insert(cmd.end(), h_cp, h_cp + sizeof(h1));
     bp_sys::supply_read_data(fd, std::move(cmd));
@@ -882,7 +882,7 @@ void cptest_wake()
     bp_sys::extract_written_data(fd, wdata);
 
     // Trying to wake s1 should now fail:
-    cmd = { DINIT_CP_WAKESERVICE, 0 /* don't pin */ };
+    cmd = { (char)cp_cmd::WAKESERVICE, 0 /* don't pin */ };
     cmd.insert(cmd.end(), h_cp, h_cp + sizeof(h1));
     bp_sys::supply_read_data(fd, std::move(cmd));
 
@@ -918,7 +918,7 @@ void cptest_servicestatus()
     handle_t h2 = find_service(fd, "test-service-2", STARTED, STARTED);
     handle_t h3 = find_service(fd, "test-service-3", STOPPED, STOPPED);
 
-    std::vector<char> cmd = { DINIT_CP_SERVICESTATUS };
+    std::vector<char> cmd = { (char)cp_cmd::SERVICESTATUS };
     char * h_cp = reinterpret_cast<char *>(&h1);
     cmd.insert(cmd.end(), h_cp, h_cp + sizeof(h1));
     bp_sys::supply_read_data(fd, std::move(cmd));
@@ -940,7 +940,7 @@ void cptest_servicestatus()
     assert(wdata[4] == 0); // various flags
 
     cmd.clear();
-    cmd.push_back(DINIT_CP_SERVICESTATUS);
+    cmd.push_back((char)cp_cmd::SERVICESTATUS);
     h_cp = reinterpret_cast<char *>(&h2);
     cmd.insert(cmd.end(), h_cp, h_cp + sizeof(h1));
     bp_sys::supply_read_data(fd, std::move(cmd));
@@ -990,7 +990,7 @@ void cptest_sendsignal()
     int sig = SIGHUP;
 
     // Issue a signal:
-    std::vector<char> cmd = { DINIT_CP_SIGNAL };
+    std::vector<char> cmd = { (char)cp_cmd::SIGNAL };
     char * sig_cp = reinterpret_cast<char *>(&sig);
     char * h_cp = reinterpret_cast<char *>(&h);
     cmd.insert(cmd.end(), sig_cp, sig_cp + sizeof(sig));
@@ -1010,7 +1010,7 @@ void cptest_sendsignal()
     sig = SIGILL;
 
     // Issue a signal:
-    cmd = { DINIT_CP_SIGNAL };
+    cmd = { (char)cp_cmd::SIGNAL };
     sig_cp = reinterpret_cast<char *>(&sig);
     cmd.insert(cmd.end(), sig_cp, sig_cp + sizeof(sig));
     cmd.insert(cmd.end(), h_cp, h_cp + sizeof(h));

--- a/src/tests/cptests/cptests.cc
+++ b/src/tests/cptests/cptests.cc
@@ -987,7 +987,7 @@ void cptest_sendsignal()
             service_state_t::STARTED);
 
     // Prepare a signal: (SIGHUP for example)
-    int sig = SIGHUP;
+    sig_num_t sig = SIGHUP;
 
     // Issue a signal:
     std::vector<char> cmd = { (char)cp_cmd::SIGNAL };


### PR DESCRIPTION
Hey, I've started to work on getting the datatypes used in the socket communication unified. (See #179 ) The types are now defined in control-datatypes.h .

The process led to a little bit of refactoring of the control commands in control-cmds.h .

Before I go on with the other datatypes and control commands I would appriciate some feedback if you have the time @mobin-2008 or @davmac314 .