### PR TITLE
add eventrequest message (wip)

### DIFF
--- a/src/includes/control-cmds.h
+++ b/src/includes/control-cmds.h
@@ -68,6 +68,9 @@ enum class cp_cmd : dinit_cptypes::cp_cmd_t {
     // Query service description directory
     QUERYSERVICEDSCDIR = 22,
 
+    // Request to trigger service event message
+    EVENTREQUEST = 23,
+
 };
 
 // Replies:
@@ -95,7 +98,7 @@ enum class cp_rply : dinit_cptypes::cp_rply_t {
 
     // Service record loaded/found
     SERVICERECORD = 59,
-    //     followed by 4-byte service handle, 1-byte service state
+    // 1-byte service state, followed by 4-byte service handle, followed by 1-byte service target state
 
     // Couldn't find/load service
     NOSERVICE = 60,

--- a/src/includes/control.h
+++ b/src/includes/control.h
@@ -164,6 +164,9 @@ class control_conn_t : private service_listener
     // Process a SIGNAL packet.
     bool process_signal();
 
+    // Process a SIGNAL packet.
+    bool process_eventrequest();
+
     // Process a QUERYSERVICEDSCDIR packet.
     bool process_query_dsc_dir();
 

--- a/src/includes/service.h
+++ b/src/includes/service.h
@@ -667,6 +667,21 @@ class service_record
         listeners.erase(listener);
     }
     
+    void notify_status() noexcept
+    {
+      switch(get_state()) {
+        case service_state_t::STARTED:
+          notify_listeners(service_event_t::STARTED);
+          break;
+        case service_state_t::STOPPED:
+          notify_listeners(service_event_t::STOPPED);
+          break;
+        default:
+          // Ignore STARTING and STOPPING states, as they result in an event anyways
+          break;
+      }
+    }
+    
     // Assuming there is one reference (from a control link), return true if this is the only reference,
     // or false if there are others (including dependents, excluding dependents via "before" and "after"
     // links).


### PR DESCRIPTION
So I had the problem, that when i tried using dinit-monitor to execute some command on service state change, there was no way of executing a command for the initial state of the service when dinit-monitor is started. This resulted in me scripting around it with first calling dinitctl for the initial status and then dinit-monitor to recieve any further changes. Pretty unsatisfying solution.

So I ceated the EVENTREQUEST request type. It should result in dinit outputting the current state of the service as event if requested.

I also added the --request flag to dinit-monitor to make it request the initial status of the monitored services upon startup.

Works fine for my usecase, but I'm not sure if/how this fits into the overall design. What are your thoughts about this @davmac314 ?