### PR TITLE
dinit monitor execute command for initial status

### DIFF
--- a/doc/manpages/dinit-monitor.8.m4
+++ b/doc/manpages/dinit-monitor.8.m4
@@ -38,12 +38,20 @@ This option determines the default path to the control socket used to communicat
 (it does not override the \fB\-p\fR option).
 .TP
 \fB\-i\fR, \fB\-\-initial\fR
-Issue the specified command additionally for the initial status of a service.
-Otherwise, the command is only executed when the status changes for the first time.
+Issue the specified command additionally for the initial status of the services (when \fBdinit\-monitor\fR is started).
+Without this option, the command is only executed whenever service status changes.
 .TP
-\fB\-\-str\-started <str>\fR, \-\-str\-stopped <str>\fR, \-\-str\-failed <str>\fR
-Specify the string which gets used for the substituion of the status (\fB%s\fR) in the command.
-The default string is equivalent to the status name itself. (See \fB\-c\fR option)
+\fB\-\-str\-started\fR \fIstarted-text\fR\br\fB\-\-test\fR
+Specify the text used for the substitution of the status in the command (as specified
+by the \fB\-\-command\fR option) when a service starts.
+.TP
+\fB\-\-str\-stopped\fR \fIstopped-text\fR
+Specify the text used for the substitution of the status in the command (as specified
+by the \fB\-\-command\fR option) when a service stops.
+.TP
+\fB\-\-str\-failed\fR \fIfailed-text\fR
+Specify the text used for the substitution of the status in the command (as specified
+by the \fB\-\-command\fR option) when a service fails to start.
 .TP
 \fB\-\-socket\-path\fR \fIsocket-path\fR, \fB\-p\fR \fIsocket-path\fR
 Specify the path to the socket used for communicating with the service manager daemon.

--- a/doc/manpages/dinit-monitor.8.m4
+++ b/doc/manpages/dinit-monitor.8.m4
@@ -37,6 +37,14 @@ Control the user init process (this is the default when not run as root).
 This option determines the default path to the control socket used to communicate with the \fBdinit\fR daemon process
 (it does not override the \fB\-p\fR option).
 .TP
+\fB\-i\fR, \fB\-\-initial\fR
+Issue the specified command additionally for the initial status of a service.
+Otherwise, the command is only executed when the status changes for the first time.
+.TP
+\fB\-\-str\-started <str>\fR, \-\-str\-stopped <str>\fR, \-\-str\-failed <str>\fR
+Specify the string which gets used for the substituion of the status (\fB%s\fR) in the command.
+The default string is equivalent to the status name itself. (See \fB\-c\fR option)
+.TP
 \fB\-\-socket\-path\fR \fIsocket-path\fR, \fB\-p\fR \fIsocket-path\fR
 Specify the path to the socket used for communicating with the service manager daemon.
 When not specified, the \fIDINIT_SOCKET_PATH\fR environment variable is read, otherwise

--- a/src/dinit-monitor.cc
+++ b/src/dinit-monitor.cc
@@ -83,7 +83,7 @@ int dinit_monitor_main(int argc, char **argv)
             else if (strcmp(argv[i], "--str-started") == 0) {
                 ++i;
                 if (i == argc) {
-                    std::cerr << "dinit-monitor: --str-started should be followed by a string\n";
+                    std::cerr << "dinit-monitor: --str-started should be followed by an argument\n";
                     return 1;
                 }
                 str_started = argv[i];
@@ -91,7 +91,7 @@ int dinit_monitor_main(int argc, char **argv)
             else if (strcmp(argv[i], "--str-stopped") == 0) {
                 ++i;
                 if (i == argc) {
-                    std::cerr << "dinit-monitor: --str-stopped should be followed by a string\n";
+                    std::cerr << "dinit-monitor: --str-stopped should be followed by an argument\n";
                     return 1;
                 }
                 str_stopped = argv[i];
@@ -99,7 +99,7 @@ int dinit_monitor_main(int argc, char **argv)
             else if (strcmp(argv[i], "--str-failed") == 0) {
                 ++i;
                 if (i == argc) {
-                    std::cerr << "dinit-monitor: --str-failed should be followed by a string\n";
+                    std::cerr << "dinit-monitor: --str-failed should be followed by an argument\n";
                     return 1;
                 }
                 str_failed = argv[i];
@@ -129,12 +129,12 @@ int dinit_monitor_main(int argc, char **argv)
                 "  -s, --system     : monitor system daemon (default if run as root)\n"
                 "  -u, --user       : monitor user daemon\n"
                 "  -i, --initial    : also execute command for initial service state\n"
-                "  --str-started <str>\n"
-                "                   : string substituted for %s when service is started\n"
-                "  --str-stopped <str>\n"
-                "                   : string substituted for %s when service is stopped\n"
-                "  --str-failed <str>\n"
-                "                   : string substituted for %s when service is failed\n"
+                "  --str-started <started-text>\n"
+                "                   : specify text describing status when service starts\n"
+                "  --str-stopped <stopped-text>\n"
+                "                   : specify text describing status when service stops\n"
+                "  --str-failed <failed-text>\n"
+                "                   : specify text describing status when service fails\n"
                 "  --socket-path <path>, -p <path>\n"
                 "                   : specify socket for communication with daemon\n"
                 "  -c, --command    : specify command to execute on service status change\n"

--- a/src/dinit-monitor.cc
+++ b/src/dinit-monitor.cc
@@ -188,6 +188,7 @@ int dinit_monitor_main(int argc, char **argv)
 
         // Load all services
         std::unordered_map<handle_t, const char *> service_map;
+        std::vector<std::pair<const char *, service_state_t>> service_init_state;
 
         for (const char *service_name : services) {
 
@@ -199,12 +200,17 @@ int dinit_monitor_main(int argc, char **argv)
             }
 
             service_map.emplace(hndl, service_name);
-            if (issue_init) {
-                if (state == service_state_t::STARTED) {
-                    issue_command(service_name, str_started, command_parts);
+            service_init_state.push_back(std::make_pair(service_name, state));
+        }
+
+        // Issue initial status commands if requested
+        if (issue_init) {
+            for (auto state : service_init_state ) {
+                if (state.second == service_state_t::STARTED) {
+                    issue_command(state.first, str_started, command_parts);
                 }
-                else if (state == service_state_t::STOPPED) {
-                    issue_command(service_name, str_stopped, command_parts);
+                else if (state.second == service_state_t::STOPPED) {
+                    issue_command(state.first, str_stopped, command_parts);
                 }
             }
         }

--- a/src/includes/control-cmds.h
+++ b/src/includes/control-cmds.h
@@ -95,7 +95,7 @@ enum class cp_rply : dinit_cptypes::cp_rply_t {
 
     // Service record loaded/found
     SERVICERECORD = 59,
-    //     followed by 4-byte service handle, 1-byte service state
+    // 1-byte service state, followed by 4-byte service handle, followed by 1-byte service target state
 
     // Couldn't find/load service
     NOSERVICE = 60,


### PR DESCRIPTION
I've refactored dinit-monitor a little bit to execute commands for the initial service state. Also added options to specify strings to be substituted per service state.