### PR TITLE
configure: Use paths from "/usr/local" on Darwin by default

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -208,8 +208,9 @@ DESTDIR:
 
     make DESTDIR=/some/path install
 
-The dinit executable will be put in /sbin (or rather, in $DESTDIR/sbin), which may not be on the
-path for normal users. Consider making a symbolic link to /usr/sbin/dinit.
+The dinit executable will be put in /sbin or /usr/local/sbin on MacOS (or rather, in $DESTDIR/sbin
+or $DESTDIR/usr/local/bin), which may not be on the path for normal users. Consider making a symbolic
+link to /usr/sbin/dinit.
 
 
 Special note for GCC/Libstdc++

--- a/configs/mconfig.Darwin
+++ b/configs/mconfig.Darwin
@@ -1,7 +1,7 @@
 # Installation path options.
 
-SBINDIR=/sbin
-MANDIR=/usr/share/man
+SBINDIR=/usr/local/sbin
+MANDIR=/usr/local/share/man
 SYSCONTROLSOCKET=/var/run/dinitctl
 
 

--- a/configure
+++ b/configure
@@ -125,8 +125,10 @@ Target options:
                                   Note: for all cross-compiles please specify correct CXX and CXX_FOR_BUILD!
 
 Installation directories:
-  --prefix=PREFIX               Main installation prefix [/usr]
-  --exec-prefix=EPREFIX         Main executables prefix  [/]
+  --prefix=PREFIX               Main installation prefix [/usr/local] on MacOS/Darwin systems
+                                                         [/usr] on other systems
+  --exec-prefix=EPREFIX         Main executables prefix  [/usr/local] on MacOS/Darwin systems
+                                                         [/] on other systems
   --sbindir=SBINDIR             Dinit executables        [EPREFIX/sbin]
   --mandir=MANDIR               Dinit man-pages location [PREFIX/share/man]
   --syscontrolsocket=SOCKETPATH Dinitctl socket location [/run/dinitctl] on Linux systems
@@ -247,8 +249,13 @@ done
 
 ## Defaults for variables not specified by user
 : "${PLATFORM:=$(uname)}"
-: "${PREFIX:="/usr"}"
-: "${EPREFIX:="/"}"
+if [ "$PLATFORM" = "Darwin" ]; then
+    : "${PREFIX:="/usr/local"}"
+    : "${EPREFIX:="/usr/local"}"
+else
+    : "${PREFIX:="/usr"}"
+    : "${EPREFIX:="/"}"
+fi
 : "${SBINDIR:="${EPREFIX%%/}/sbin"}"
 : "${MANDIR:="${PREFIX%%/}/share/man"}"
 : "${SHUTDOWN_PREFIX:=""}"


### PR DESCRIPTION
SIP (System Integrity Protection) is a feature introduced in OS X El Capitan which protects some paths (include "/usr`) from modifying or overwriting. This patch changes "SBINDIR" and "MANDIR" to paths from "/usr/local/" by default on MacOS.

Fixes #266 

`Signed-off-by: Mobin "Hojjat" Aydinfar <mobin@mobintestserver.ir>`