### PR TITLE
configure: Fix "parameter is not set" failure on setting "LDFLAGS_BASE"

### DIFF
--- a/configure
+++ b/configure
@@ -310,7 +310,7 @@ if [ -z "${LDFLAGS_BASE+IS_SET}" ]; then
     LDFLAGS_BASE=""
     AUTO_LDFLAGS_BASE="true"
 else
-    AUTO_LDFLAGS=BASE="false"
+    AUTO_LDFLAGS_BASE="false"
 fi
 if [ -z "${TEST_LDFLAGS_BASE+IS_SET}" ]; then
     TEST_LDFLAGS_BASE=""


### PR DESCRIPTION
`Signed-off-by: Mobin "Hojjat" Aydinfar <mobin@mobintestserver.ir>`