### PR TITLE
rename "regular" in `dinitctl add-dep` to "need"

### DIFF
--- a/doc/manpages/dinitctl.8.m4
+++ b/doc/manpages/dinitctl.8.m4
@@ -281,6 +281,8 @@ The \fIdependency-type\fR must be one of \fBneed\fR, \fBmilestone\fR or \fBwaits
 Note that adding a \fBneed\fR dependency requires that the service states are consistent with the
 dependency (i.e. if the "from" service is started, the "to" service must also be started).
 Circular dependency chains may not be created.
+.sp
+(deprecated) The \fIdependency-type\fR \fBregular\fR is an old alias of \fBneed\fR.
 .TP
 \fBrm-dep\fR
 Remove a dependency between two services.

--- a/doc/manpages/dinitctl.8.m4
+++ b/doc/manpages/dinitctl.8.m4
@@ -277,14 +277,14 @@ If issued to the system instance of Dinit, this will also shut down the system.
 .TP
 \fBadd-dep\fR
 Add a dependency between two services.
-The \fIdependency-type\fR must be one of \fBregular\fR, \fBmilestone\fR or \fBwaits-for\fR.
-Note that adding a regular dependency requires that the service states are consistent with the
+The \fIdependency-type\fR must be one of \fBneed\fR, \fBmilestone\fR or \fBwaits-for\fR.
+Note that adding a \fBneed\fR dependency requires that the service states are consistent with the
 dependency (i.e. if the "from" service is started, the "to" service must also be started).
 Circular dependency chains may not be created.
 .TP
 \fBrm-dep\fR
 Remove a dependency between two services.
-The \fIdependency-type\fR must be one of \fBregular\fR, \fBmilestone\fR or \fBwaits-for\fR.
+The \fIdependency-type\fR must be one of \fBneed\fR, \fBmilestone\fR or \fBwaits-for\fR.
 If the "to" service is not otherwise active it may be stopped as a result of removing the dependency.
 .TP
 \fBenable\fR

--- a/src/dinitctl.cc
+++ b/src/dinitctl.cc
@@ -295,7 +295,7 @@ int dinitctl_main(int argc, char **argv)
             // service name / other non-option
             if (command == ctl_cmd::ADD_DEPENDENCY || command == ctl_cmd::RM_DEPENDENCY) {
                 if (! dep_type_set) {
-                    if (strcmp(argv[i], "regular") == 0) {
+                    if (strcmp(argv[i], "need") == 0 || strcmp(argv[i], "regular") == 0) {
                         dep_type = dependency_type::REGULAR;
                     }
                     else if (strcmp(argv[i], "milestone") == 0) {

--- a/src/igr-tests/before-after2/run-test.sh
+++ b/src/igr-tests/before-after2/run-test.sh
@@ -15,7 +15,7 @@ spawn_dinit
 run_dinitctl $QUIET reload service2
 
 # however, we'll remove the depends-on dependency before starting both
-run_dinitctl $QUIET rm-dep regular service2 service1
+run_dinitctl $QUIET rm-dep need service2 service1
 
 run_dinitctl $QUIET start --no-wait service1
 run_dinitctl $QUIET start service2


### PR DESCRIPTION

Not sure if this change is good, but it solves the inconsistency mentioned in #295.
Maybe we should mention both "regular" and "need" in the `dinitctl` man page?

fixes #295.