### PR TITLE
System-wide location for user services

### DIFF
--- a/doc/manpages/dinit.8.m4
+++ b/doc/manpages/dinit.8.m4
@@ -32,7 +32,8 @@ See \fBRUNNING AS SYSTEM MANAGER / PRIMARY INIT\fR.
 Dinit reads service descriptions from files located in a service
 description directory, normally one of \fI/etc/dinit.d\fR, \fI/run/dinit.d\fR,
 \fI/usr/local/lib/dinit.d\fR and \fI/lib/dinit.d\fR for the system instance
-or \fI$XDG_CONFIG_HOME/dinit.d\fR and \fI$HOME/.config/dinit.d\fR when run as a user process.
+or \fI$XDG_CONFIG_HOME/dinit.d\fR, \fI$HOME/.config/dinit.d\fR and \fI/etc/dinit.d/user\fR when run
+as a user process.
 See \fBSERVICE DESCRIPTION FILES\fR for details of the service description format.
 .\"
 .SH OPTIONS
@@ -42,9 +43,10 @@ Specifies \fIdir\fP as the directory containing service definition files.
 This can be specified multiple times for multiple service directories.
 The default directories are not searched for services when this option is provided.
 .sp
-If not specified, the default for the user instance is \fI$XDG_CONFIG_HOME/dinit.d\fR
-and \fI$HOME/.config/dinit.d\fR or, for the system instance, each of \fI/etc/dinit.d\fR,
-\fI/run/dinit.d/\fR, \fI/usr/local/lib/dinit.d\fR, and \fI/lib/dinit.d\fR (searched in that order).
+If not specified, the default for the user instance is \fI$XDG_CONFIG_HOME/dinit.d\fR, 
+\fI$HOME/.config/dinit.d\fR and \fI/etc/dinit.d/user\fR or, for the system instance, each of 
+\fI/etc/dinit.d\fR, \fI/run/dinit.d/\fR, \fI/usr/local/lib/dinit.d\fR, and \fI/lib/dinit.d\fR
+(searched in that order).
 .TP
 \fB\-e\fR \fIfile\fP, \fB\-\-env\-file\fR \fIfile\fP
 Read initial environment from \fIfile\fP.

--- a/src/options-processing.cc
+++ b/src/options-processing.cc
@@ -75,6 +75,7 @@ void service_dir_opt::build_paths(bool am_system_init)
         }
 
         done_user_home:
+        service_dir_paths.emplace_back("/etc/dinit.d/user", /*dyn_allocd=*/false);
 
         if (!home_service_dir_set) {
             service_dir_paths.emplace_back("/etc/dinit.d", /*dyn_allocd=*/false);


### PR DESCRIPTION
The service in `$HOME/.config/dinit.d` overrides `/etc/dinit.d/user` version.
And services in the latter work.