### PR TITLE
configure: Don't invoke linker for checking flags for compiler

### DIFF
--- a/configure
+++ b/configure
@@ -71,7 +71,7 @@ cxx_works()
 try_cxx_argument()
 {
     info Checking whether the compiler accepts "$2"...
-    if $CXX $CXXFLAGS $2 $CXXFLAGS_EXTRA $LDFLAGS $LDFLAGS_EXTRA testfile.cc -o testfile > /dev/null 2>&1; then
+    if $CXX -c $CXXFLAGS $2 $CXXFLAGS_EXTRA $LDFLAGS $LDFLAGS_EXTRA testfile.cc -o testfile > /dev/null 2>&1; then
         rm testfile
         sub_info Yes.
         eval "$1=\"\${$1} \$2\""


### PR DESCRIPTION
It makes into 50% better speed (from 2s to 1s on my test subject) and actually makes sense because in "try_cxx_argument" we're looking for flags that compiles not links.

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`