### PR TITLE
meson.build: add poweroff bin

### DIFF
--- a/doc/manpages/meson.build
+++ b/doc/manpages/meson.build
@@ -25,7 +25,7 @@ foreach man: ['dinit-service.5', 'dinit.8', 'dinitcheck.8', 'dinitctl.8', 'dinit
     )
 endforeach
 if shutdown_built
-    foreach shutdown_man: ['shutdown.8', 'reboot.8', 'halt.8']
+    foreach shutdown_man: ['shutdown.8', 'reboot.8', 'halt.8', 'poweroff.8']
         custom_target(
             shutdown_man,
             input: 'shutdown.8.m4',

--- a/src/meson.build
+++ b/src/meson.build
@@ -61,7 +61,7 @@ executable(
 # Shutdown/reboot/halt
 if build_shutdown.auto() and platform == 'linux' or build_shutdown.enabled()
     shutdown_built = true
-    foreach exec: ['shutdown', 'reboot', 'halt']
+    foreach exec: ['shutdown', 'reboot', 'halt', 'poweroff']
         executable(
             shutdown_prefix + exec,
             'shutdown.cc',


### PR DESCRIPTION
## Description

Self-explanatory.

This will make the meson build 1:1 with the Makefile build, since the Makefile build already has poweroff but not meson.