### PR TITLE
CI: Use "brew" for installing meson in meson-based workflow

### DIFF
--- a/.github/workflows/meson_ci.yml
+++ b/.github/workflows/meson_ci.yml
@@ -93,10 +93,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Install meson via pip3
-      run: pip3 install meson
-    - name: Install ninja
-      run: brew install ninja
+    - name: Install meson
+      run: brew install meson
     - name: Setup
       run: meson setup -Dunit-tests=true -Digr-tests=true dirbuild
     - name: Build


### PR DESCRIPTION
The MacOS version used in GitHub actions is upgraded. This version does block installing a system-wide program through "pip". Just use "brew" for installing meson.

(This PR also removes install step for ninja, because it will be installed in meson
installation process)

`Signed-off-by: Mobin Aydinfar <mobin@mobinttestserver.ir>`