### PR TITLE
src/meson.build: install poweroff, reboot, and halt as symlinks

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project(
     version : run_command('grep', '^VERSION=', 'build/version.conf',
         check: true).stdout().strip().split('=')[1],
     license : 'Apache-2.0',
-    meson_version : '>= 0.56.0',
+    meson_version : '>= 0.61.0',
     default_options : [
         'cpp_std=c++11',
         'optimization=s',

--- a/src/meson.build
+++ b/src/meson.build
@@ -61,11 +61,16 @@ executable(
 # Shutdown/reboot/halt
 if build_shutdown.auto() and platform == 'linux' or build_shutdown.enabled()
     shutdown_built = true
-    foreach exec: ['shutdown', 'reboot', 'halt', 'poweroff']
-        executable(
-            shutdown_prefix + exec,
-            'shutdown.cc',
-            kwargs: misc_args
+    executable(
+        shutdown_prefix + 'shutdown',
+        'shutdown.cc',
+        kwargs: misc_args
+    )
+    foreach exec: ['reboot', 'halt', 'poweroff']
+        install_symlink(
+            exec,
+            pointing_to: 'shutdown',
+            install_dir: sbindir
         )
     endforeach
 endif


### PR DESCRIPTION
## Description

Self-explanatory.

This should close #325, unfortunately since it uses `install_symlink`, it requires a newer version of meson.