### PR TITLE
CI: Upgrade Debian workflow to bookworm

### DIFF
--- a/.github/workflows/meson_ci.yml
+++ b/.github/workflows/meson_ci.yml
@@ -38,12 +38,12 @@ on:
 
 jobs:
 
-  Debian-bullseye_build:
+  Debian-bookworm_build:
 
     if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'meson') }}
     runs-on: ubuntu-latest
     container:
-      image: debian:bullseye
+      image: debian:bookworm
     strategy:
       fail-fast: false # Upload src/igr-tests/*/output/* files in igr-tests
       matrix:


### PR DESCRIPTION
We recently bumped required version of Meson to 0.63 and debian bullseye doesn't have it.

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`