### PR TITLE
Tweak FreeBSD install instruction

### DIFF
--- a/contrib/freebsd-rc/README
+++ b/contrib/freebsd-rc/README
@@ -9,9 +9,9 @@ cd build2
 ninja install
 popd
 
-# Install rc.d
-cp tree/etc/rc.d/dinit /etc/rc.d/dinit
-cp tree/usr/sbin/dinitd /usr/sbin/dinitd
+# Install dinit as rc.d service
+rsync -r tree/ /
+mkdir -p /etc/dinit.d/boot.d
 
 # enable dinit (to start on next boot)
 /etc/rc.d/dinit enable

--- a/contrib/freebsd-rc/README
+++ b/contrib/freebsd-rc/README
@@ -1,8 +1,12 @@
 Support files for launching dinit from /etc/rc.d/ on FreeBSD
 
-```
-# Build dinit with correct path
+To install dinit on FreeBSD, run the following commands as root:
 
+```
+# (Optional) Install build dependencies
+pkg install -y meson rsync
+
+# Build dinit with correct path
 pushd ../..
 meson setup -Ddinit-control-socket-path=/var/run/dinitctl build2
 cd build2

--- a/contrib/freebsd-rc/tree/etc/dinit.d/boot
+++ b/contrib/freebsd-rc/tree/etc/dinit.d/boot
@@ -1,0 +1,4 @@
+# The primary service
+
+type = internal
+waits-for.d = boot.d


### PR DESCRIPTION
I installed dinit on FreeBSD again. The script in README should now do everything needed to install dinit to run under rc.d.


Related future plan:  
to create a port: https://docs.freebsd.org/en/books/porters-handbook/quick-porting/