### PR TITLE
shutdown: Respect "SHUTDOWN_PREFIX" for reboot util check

### DIFF
--- a/src/shutdown.cc
+++ b/src/shutdown.cc
@@ -18,6 +18,7 @@
 #include "cpbuffer.h"
 #include "control-cmds.h"
 #include "service-constants.h"
+#include "static-string.h"
 #include "dinit-client.h"
 #include "dinit-util.h"
 #include "mconfig.h"
@@ -30,6 +31,8 @@
 
 static constexpr uint16_t min_cp_version = 1;
 static constexpr uint16_t max_cp_version = 1;
+
+static constexpr auto reboot_execname = cts::literal(SHUTDOWN_PREFIX) + cts::literal("reboot");
 
 using loop_t = dasynq::event_loop_n;
 using rearm = dasynq::rearm;
@@ -253,7 +256,7 @@ int main(int argc, char **argv)
     auto shutdown_type = shutdown_type_t::POWEROFF;
 
     const char *execname = base_name(argv[0]);
-    if (strcmp(execname, "reboot") == 0) {
+    if (strcmp(execname, reboot_execname) == 0) {
         shutdown_type = shutdown_type_t::REBOOT;
     }
         


### PR DESCRIPTION
It was a bug that shutdown executable only checked "reboot" string to find out this should be a reboot or normal shutdown.

Regression: It's not, because it was broken from the beginning.

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`