### PR TITLE
meson: Use `igr-runner` for igr-tests

### DIFF
--- a/src/igr-tests/Makefile
+++ b/src/igr-tests/Makefile
@@ -5,7 +5,7 @@ check-igr: igr-runner
 	IGR_OUTPUT_BASE=$$PWD/igr-output ./igr-runner
 
 igr-runner: igr-runner.cc igr.h
-	$(CXX) $(CXXFLAGS) $(CXXFLAGS_EXTRA) -I../../dasynq/include  $(LDFLAGS) $(LDFLAGS_EXTRA) igr-runner.cc -o igr-runner
+	$(CXX) $(CXXFLAGS) $(CXXFLAGS_EXTRA) -I../../dasynq/include -I../../build/includes $(LDFLAGS) $(LDFLAGS_EXTRA) igr-runner.cc -o igr-runner
 
 clean:
 	rm -f igr-runner

--- a/src/igr-tests/igr-runner.cc
+++ b/src/igr-tests/igr-runner.cc
@@ -16,8 +16,6 @@ extern char **environ;
 
 // Integration test suite runner.
 
-std::string igr_dinit_socket_path;
-
 void basic_test();
 void environ_test();
 void environ2_test();
@@ -62,18 +60,26 @@ int main(int argc, char **argv)
             { "xdg-config", xdg_config_test }, { "cycles", cycles_test } };
     constexpr int num_tests = sizeof(tests) / sizeof(tests[0]);
 
-    dinit_bindir = "../.."; // XXX
-    igr_output_basedir = "igr-output"; // XXX
+    dinit_bindir = "../..";
+    char *env_dinit_bindir = getenv("DINIT_BINDIR");
+    if (env_dinit_bindir != nullptr) {
+        dinit_bindir = env_dinit_bindir;
+    }
 
-    int passed = 0;
-    int failed = 0;
-
+    igr_output_basedir = "igr-output";
     char *env_igr_output_base = getenv("IGR_OUTPUT_BASE");
     if (env_igr_output_base != nullptr) {
         igr_output_basedir = env_igr_output_base;
     }
 
-    igr_dinit_socket_path = igr_output_basedir + "/dinit.socket";
+    igr_input_basedir = get_full_cwd() + "/";
+    char *env_igr_input_basedir = getenv("IGR_INPUT_BASE");
+    if (env_igr_input_basedir != nullptr) {
+        igr_input_basedir = env_igr_input_basedir;
+    }
+
+    int passed = 0;
+    int failed = 0;
 
     std::cout << "============== INTEGRATION TESTS =====================" << std::endl;
 
@@ -145,10 +151,11 @@ void basic_test()
 {
     igr_test_setup setup("basic");
     std::string ran_file = setup.prep_output_file("basic-ran");
+    std::string socket_path = setup.prep_socket_path();
 
     // Start the "basic" service. This creates an output file, "basic-ran", containing "ran\n".
     dinit_proc dinit_p;
-    dinit_p.start("basic", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q", "basic"});
+    dinit_p.start("basic", {"-u", "-d", "sd", "-p", socket_path, "-q", "basic"});
     dinit_p.wait_for_term({1,0} /* max 1 second */);
 
     igr_assert_eq("", dinit_p.get_stdout());
@@ -161,22 +168,23 @@ void environ_test()
 {
     igr_test_setup setup("environ");
     std::string output_file = setup.prep_output_file("env-record");
+    std::string socket_path = setup.prep_socket_path();
 
     igr_env_var_setup env_output("OUTPUT", output_file.c_str());
-    igr_env_var_setup env_socket("SOCKET", igr_dinit_socket_path.c_str());
+    igr_env_var_setup env_socket("SOCKET", socket_path.c_str());
     igr_env_var_setup env_dinitctl("DINITCTL", (dinit_bindir + "/dinitctl").c_str());
 
     dinit_proc dinit_p;
-    dinit_p.start("environ", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q", "-e", "environment1", "checkenv"});
+    dinit_p.start("environ", {"-u", "-d", "sd", "-p", socket_path, "-q", "-e", "environment1", "checkenv"});
     dinit_p.wait_for_term({1,0} /* max 1 second */);
 
-    dinit_p.start("environ", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q", "-e", "environment2", "checkenv"});
+    dinit_p.start("environ", {"-u", "-d", "sd", "-p", socket_path, "-q", "-e", "environment2", "checkenv"});
     dinit_p.wait_for_term({1,0} /* max 1 second */);
 
-    dinit_p.start("environ", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, /* "-q", */ "setenv1"});
+    dinit_p.start("environ", {"-u", "-d", "sd", "-p", socket_path, /* "-q", */ "setenv1"});
     dinit_p.wait_for_term({1,0} /* max 1 second */);
 
-    check_file_contents(output_file, igr_dinit_socket_path + "\n" +
+    check_file_contents(output_file, socket_path + "\n" +
             "checkenv\n" +
             "gotenv1\n" +
             "hello\n" +
@@ -189,6 +197,7 @@ void environ2_test()
 {
     igr_test_setup setup("environ2");
     std::string output_file = setup.prep_output_file("env-record");
+    std::string socket_path = setup.prep_socket_path();
 
     uid_t my_uid = getuid();
     gid_t my_gid = getgid();
@@ -208,7 +217,7 @@ void environ2_test()
     igr_env_var_setup env_test_var("TEST_VAR", "helloworld");
 
     dinit_proc dinit_p;
-    dinit_p.start("environ2", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q", "-e", "env-dinit", "checkenv"});
+    dinit_p.start("environ2", {"-u", "-d", "sd", "-p", socket_path, "-q", "-e", "env-dinit", "checkenv"});
     dinit_p.wait_for_term({1,0} /* max 1 second */);
 
     check_file_contents(output_file,
@@ -226,70 +235,73 @@ void ps_environ_test()
 {
     igr_test_setup setup("ps-environ");
     std::string output_file = setup.prep_output_file("env-record");
+    std::string socket_path = setup.prep_socket_path();
 
     igr_env_var_setup env_output("OUTPUT", output_file.c_str());
     igr_env_var_setup env_test_var_two("TEST_VAR_TWO", "set-via-script");
 
     dinit_proc dinit_p;
-    dinit_p.start("ps-environ", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q", "checkenv1"});
+    dinit_p.start("ps-environ", {"-u", "-d", "sd", "-p", socket_path, "-q", "checkenv1"});
     dinit_p.wait_for_term({1,0} /* max 1 second */);
 
-    dinit_p.start("ps-environ", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q", "checkenv2"});
+    dinit_p.start("ps-environ", {"-u", "-d", "sd", "-p", socket_path, "-q", "checkenv2"});
     dinit_p.wait_for_term({1,0} /* max 1 second */);
 
-    dinit_p.start("ps-environ", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q", "checkenv3"});
+    dinit_p.start("ps-environ", {"-u", "-d", "sd", "-p", socket_path, "-q", "checkenv3"});
     dinit_p.wait_for_term({1,0} /* max 1 second */);
 
     // "set-in-dinit-env"
-    dinit_p.start("ps-environ", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q", "-e", "dinit-environment", "checkenv4"});
+    dinit_p.start("ps-environ", {"-u", "-d", "sd", "-p", socket_path, "-q", "-e", "dinit-environment", "checkenv4"});
     dinit_p.wait_for_term({1,0} /* max 1 second */);
 
     // "set-via-script" (as per above)
-    dinit_p.start("ps-environ", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q", "checkenv4"});
+    dinit_p.start("ps-environ", {"-u", "-d", "sd", "-p", socket_path, "-q", "checkenv4"});
     dinit_p.wait_for_term({1,0} /* max 1 second */);
 
-    check_file_contents(output_file, read_file_contents("./ps-environ/env-expected"));
+    check_file_contents(output_file, read_file_contents(igr_input_basedir + "/ps-environ/env-expected"));
 }
 
 void chain_to_test()
 {
     igr_test_setup setup("chain-to");
     std::string output_file = setup.prep_output_file("recorded-output");
+    std::string socket_path = setup.prep_socket_path();
 
     dinit_proc dinit_p;
-    dinit_p.start("chain-to", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q", "part1"});
+    dinit_p.start("chain-to", {"-u", "-d", "sd", "-p", socket_path, "-q", "part1"});
     dinit_p.wait_for_term({1,0} /* max 1 second */);
 
-    check_file_contents(output_file, read_file_contents("./chain-to/expected-output"));
+    check_file_contents(output_file, read_file_contents(igr_input_basedir + "/chain-to/expected-output"));
 }
 
 void force_stop_test()
 {
     igr_test_setup setup("force-stop");
+    std::string socket_path = setup.prep_socket_path();
 
     dinit_proc dinit_p;
-    dinit_p.start("force-stop", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q"}, true);
+    dinit_p.start("force-stop", {"-u", "-d", "sd", "-p", socket_path, "-q"}, true);
 
     // "dinitctl list"
     dinitctl_proc dinitctl_p;
-    dinitctl_p.start("force-stop", {"-p", igr_dinit_socket_path, "list"});
+    dinitctl_p.start("force-stop", {"-p", socket_path, "list"});
     dinitctl_p.wait_for_term({1, 0}  /* max 1 second */);
 
-    igr_assert_eq(read_file_contents("./force-stop/expected-1"), dinitctl_p.get_stdout());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/force-stop/expected-1"), dinitctl_p.get_stdout());
     igr_assert_eq("", dinitctl_p.get_stderr());
 
     // "dinitctl stop critical"
-    dinitctl_p.start("force-stop", {"-p", igr_dinit_socket_path, "stop", "critical"});
+    dinitctl_p.start("force-stop", {"-p", socket_path, "stop", "critical"});
     dinitctl_p.wait_for_term({1, 0}  /* max 1 second */);
 
     igr_assert_eq("", dinitctl_p.get_stdout());
-    igr_assert_eq(read_file_contents("./force-stop/expected-2.err"), dinitctl_p.get_stderr());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/force-stop/expected-2.err"), dinitctl_p.get_stderr());
 
     // "dinitctl stop --force critical"
-    dinitctl_p.start("force-stop", {"-p", igr_dinit_socket_path, "stop", "--force", "critical"});
+    dinitctl_p.start("force-stop", {"-p", socket_path, "stop", "--force", "critical"});
     dinitctl_p.wait_for_term({1, 0}  /* max 1 second */);
 
-    igr_assert_eq(read_file_contents("./force-stop/expected-3"), dinitctl_p.get_stdout());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/force-stop/expected-3"), dinitctl_p.get_stdout());
     igr_assert_eq("", dinitctl_p.get_stderr());
 
     // dinit should stop since all services are now stopped
@@ -300,13 +312,14 @@ void restart_test()
 {
     igr_test_setup setup("restart");
     std::string output_file = setup.prep_output_file("basic-ran");
+    std::string socket_path = setup.prep_socket_path();
 
     dinit_proc dinit_p;
-    dinit_p.start("restart", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q"}, true);
+    dinit_p.start("restart", {"-u", "-d", "sd", "-p", socket_path, "-q"}, true);
 
     // "dinitctl start boot" - wait until "boot" has fully started:
     dinitctl_proc dinitctl_p;
-    dinitctl_p.start("restart", {"-p", igr_dinit_socket_path, "start", "boot"});
+    dinitctl_p.start("restart", {"-p", socket_path, "start", "boot"});
     dinitctl_p.wait_for_term({1, 0}  /* max 1 second */);
 
     // "basic" is a process service. It has started, but we need to give it a little time to
@@ -319,7 +332,7 @@ void restart_test()
     }
 
     // "dinitctl restart basic"
-    dinitctl_p.start("restart", {"-p", igr_dinit_socket_path, "restart", "basic"});
+    dinitctl_p.start("restart", {"-p", socket_path, "restart", "basic"});
     dinitctl_p.wait_for_term({1, 0}  /* max 1 second */);
 
     nanosleepx(0, 1000000000u / 10u);
@@ -332,7 +345,7 @@ void check_basic_test()
     igr_test_setup setup("check-basic");
 
     auto check_result = run_dinitcheck("check-basic", {"-d", "sd"});
-    igr_assert_eq(read_file_contents("./check-basic/expected.txt"), check_result.first);
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/check-basic/expected.txt"), check_result.first);
     igr_assert(WEXITSTATUS(check_result.second) == 1, "dinitcheck exit status == 1");
 }
 
@@ -341,7 +354,7 @@ void check_cycle_test()
     igr_test_setup setup("check-cycle");
 
     auto check_result = run_dinitcheck("check-cycle", {"-d", "sd"});
-    igr_assert_eq(read_file_contents("./check-cycle/expected.txt"), check_result.first);
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/check-cycle/expected.txt"), check_result.first);
     igr_assert(WEXITSTATUS(check_result.second) == 1, "dinitcheck exit status == 1");
 }
 
@@ -350,7 +363,7 @@ void check_cycle2_test()
     igr_test_setup setup("check-cycle2");
 
     auto check_result = run_dinitcheck("check-cycle2", {"-d", "sd"});
-    igr_assert_eq(read_file_contents("./check-cycle2/expected.txt"), check_result.first);
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/check-cycle2/expected.txt"), check_result.first);
     igr_assert(WEXITSTATUS(check_result.second) == 1, "dinitcheck exit status == 1");
 }
 
@@ -359,15 +372,14 @@ void check_lint_test()
     igr_test_setup setup("check-lint");
 
     auto check_result = run_dinitcheck("check-lint", {"-d", "sd"});
-    igr_assert_eq(read_file_contents("./check-lint/expected.txt"), check_result.first);
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/check-lint/expected.txt"), check_result.first);
     igr_assert(WEXITSTATUS(check_result.second) == 1, "dinitcheck exit status == 1");
 }
 
 void reload1_test()
 {
     igr_test_setup setup("reload1");
-
-    auto cwd = get_full_cwd();
+    std::string socket_path = setup.prep_socket_path();
 
     // This test requires reloading services after modifying a service description,
     // which for convenience we do by replacing the entire service directory (sd1 with sd2).
@@ -376,58 +388,60 @@ void reload1_test()
 
     std::string sd_dir = setup.get_output_dir() + "/sd";
     unlink(sd_dir.c_str());
-    if (symlink((cwd + "/reload1/sd1").c_str(), sd_dir.c_str()) == -1) {
+    if (symlink((igr_input_basedir + "/reload1/sd1").c_str(), sd_dir.c_str()) == -1) {
         throw std::system_error(errno, std::generic_category(), "symlink");
     }
 
     dinit_proc dinit_p;
-    dinit_p.start("reload1", {"-u", "-d", sd_dir.c_str(), "-p", igr_dinit_socket_path, "-q"}, true);
+    dinit_p.start("reload1", {"-u", "-d", sd_dir.c_str(), "-p", socket_path, "-q"}, true);
 
     // "dinitctl list" and check output
     dinitctl_proc dinitctl_p;
-    dinitctl_p.start("reload1", {"-p", igr_dinit_socket_path, "list"});
+    dinitctl_p.start("reload1", {"-p", socket_path, "list"});
     dinitctl_p.wait_for_term({1, 0}  /* max 1 second */);
 
     igr_assert_eq("", dinitctl_p.get_stderr());
-    igr_assert_eq(read_file_contents("./reload1/initial.expected"), dinitctl_p.get_stdout());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/reload1/initial.expected"),
+            dinitctl_p.get_stdout());
 
     // Replace service directory with sd2
     unlink(sd_dir.c_str());
-    if (symlink((cwd + "/reload1/sd2").c_str(), sd_dir.c_str()) == -1) {
+    if (symlink((igr_input_basedir + "/reload1/sd2").c_str(), sd_dir.c_str()) == -1) {
         throw std::system_error(errno, std::generic_category(), "symlink");
     }
 
     // reload should fail: c not started but is a dependency in the new service description
-    dinitctl_p.start("reload1", {"--quiet", "-p", igr_dinit_socket_path, "reload", "boot"});
+    dinitctl_p.start("reload1", {"--quiet", "-p", socket_path, "reload", "boot"});
     dinitctl_p.wait_for_term({1, 0}  /* max 1 second */);
 
-    igr_assert_eq(read_file_contents("./reload1/output2.expected"), dinitctl_p.get_stderr());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/reload1/output2.expected"),
+            dinitctl_p.get_stderr());
     igr_assert_eq("", dinitctl_p.get_stdout());
 
     // if we start c, should then be able to do the reload
-    dinitctl_p.start("reload1", {"--quiet", "-p", igr_dinit_socket_path, "start", "c"});
+    dinitctl_p.start("reload1", {"--quiet", "-p", socket_path, "start", "c"});
     dinitctl_p.wait_for_term({1, 0}  /* max 1 second */);
     igr_assert_eq("", dinitctl_p.get_stderr());
     igr_assert_eq("", dinitctl_p.get_stdout());
 
-    dinitctl_p.start("reload1", {"--quiet", "-p", igr_dinit_socket_path, "reload", "boot"});
+    dinitctl_p.start("reload1", {"--quiet", "-p", socket_path, "reload", "boot"});
     dinitctl_p.wait_for_term({1, 0}  /* max 1 second */);
     igr_assert_eq("", dinitctl_p.get_stderr());
     igr_assert_eq("", dinitctl_p.get_stdout());
 
     // list again and check output
-    dinitctl_p.start("reload1", {"-p", igr_dinit_socket_path, "list"});
+    dinitctl_p.start("reload1", {"-p", socket_path, "list"});
     dinitctl_p.wait_for_term({1, 0}  /* max 1 second */);
 
     igr_assert_eq("", dinitctl_p.get_stderr());
-    igr_assert_eq(read_file_contents("./reload1/output3.expected"), dinitctl_p.get_stdout());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/reload1/output3.expected"),
+            dinitctl_p.get_stdout());
 }
 
 void reload2_test()
 {
     igr_test_setup setup("reload2");
-
-    auto cwd = get_full_cwd();
+    std::string socket_path = setup.prep_socket_path();
 
     // This test requires reloading services after modifying a service description,
     // which for convenience we do by replacing the entire service directory (sd1 with sd2).
@@ -436,51 +450,54 @@ void reload2_test()
 
     std::string sd_dir = setup.get_output_dir() + "/sd";
     unlink(sd_dir.c_str());
-    if (symlink((cwd + "/reload2/sd1").c_str(), sd_dir.c_str()) == -1) {
+    if (symlink((igr_input_basedir + "/reload2/sd1").c_str(), sd_dir.c_str()) == -1) {
         throw std::system_error(errno, std::generic_category(), "symlink");
     }
 
     dinit_proc dinit_p;
-    dinit_p.start("reload2", {"-u", "-d", sd_dir.c_str(), "-p", igr_dinit_socket_path, "-q"}, true);
+    dinit_p.start("reload2", {"-u", "-d", sd_dir.c_str(), "-p", socket_path, "-q"}, true);
 
     // Start "hold" service (allows us to stop "boot" without stopping dinit)
     dinitctl_proc dinitctl_p;
-    dinitctl_p.start("reload2", {"-p", igr_dinit_socket_path, "start", "hold"});
+    dinitctl_p.start("reload2", {"-p", socket_path, "start", "hold"});
     dinitctl_p.wait_for_term({1, 0}  /* max 1 second */);
 
     // "dinitctl list" and check output
-    dinitctl_p.start("reload2", {"-p", igr_dinit_socket_path, "list"});
+    dinitctl_p.start("reload2", {"-p", socket_path, "list"});
     dinitctl_p.wait_for_term({1, 0}  /* max 1 second */);
 
     igr_assert_eq("", dinitctl_p.get_stderr());
-    igr_assert_eq(read_file_contents("./reload2/initial.expected"), dinitctl_p.get_stdout());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/reload2/initial.expected"),
+            dinitctl_p.get_stdout());
 
     // "dinitctl stop boot"
-    dinitctl_p.start("reload2", {"-p", igr_dinit_socket_path, "stop", "boot"});
+    dinitctl_p.start("reload2", {"-p", socket_path, "stop", "boot"});
     dinitctl_p.wait_for_term({1, 0}  /* max 1 second */);
 
     // Replace service directory with sd2
     unlink(sd_dir.c_str());
-    if (symlink((cwd + "/reload2/sd2").c_str(), sd_dir.c_str()) == -1) {
+    if (symlink((igr_input_basedir + "/reload2/sd2").c_str(), sd_dir.c_str()) == -1) {
         throw std::system_error(errno, std::generic_category(), "symlink");
     }
 
     // "dinitctl reload boot", should succeed
-    dinitctl_p.start("reload2", {"-p", igr_dinit_socket_path, "reload", "boot"});
+    dinitctl_p.start("reload2", {"-p", socket_path, "reload", "boot"});
     int dinitctl_result = dinitctl_p.wait_for_term({1, 0}  /* max 1 second */);
     igr_assert(WEXITSTATUS(dinitctl_result) == 0, "\"dinitctl reload boot\" returned unexpected status");
-    igr_assert_eq(read_file_contents("./reload2/output2.expected"), dinitctl_p.get_stdout());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/reload2/output2.expected"),
+            dinitctl_p.get_stdout());
     igr_assert_eq("", dinitctl_p.get_stderr());
 
     // "dinitctl start boot"
-    dinitctl_p.start("reload2", {"-p", igr_dinit_socket_path, "start", "boot"});
+    dinitctl_p.start("reload2", {"-p", socket_path, "start", "boot"});
     dinitctl_result = dinitctl_p.wait_for_term({1, 0}  /* max 1 second */);
     igr_assert(WEXITSTATUS(dinitctl_result) == 0, "\"dinitctl start boot\" returned unexpected status");
 
     // "dinitctl list"
-    dinitctl_p.start("reload2", {"-p", igr_dinit_socket_path, "list"});
+    dinitctl_p.start("reload2", {"-p", socket_path, "list"});
     dinitctl_p.wait_for_term({1, 0}  /* max 1 second */);
-    igr_assert_eq(read_file_contents("./reload2/output3.expected"), dinitctl_p.get_stdout());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/reload2/output3.expected"),
+            dinitctl_p.get_stdout());
     igr_assert_eq("", dinitctl_p.get_stderr());
 }
 
@@ -489,10 +506,11 @@ void no_command_error_test()
     // Check that a service without a command configured causes the appropriate error.
 
     igr_test_setup setup("no-command-error");
+    std::string socket_path = setup.prep_socket_path();
 
     std::string sd_dir = setup.get_output_dir() + "/sd";
 
-    std::vector<std::string> dinit_args {"-u", "-d", "sd", "-p", igr_dinit_socket_path};
+    std::vector<std::string> dinit_args {"-u", "-d", "sd", "-p", socket_path};
 
 #if SUPPORT_CGROUPS
     // If cgroups support, supply dummy cgroup base path to avoid "unable to determine cgroup" message
@@ -506,58 +524,60 @@ void no_command_error_test()
     dinit_p.start("no-command-error", dinit_args);
     dinit_p.wait_for_term({1, 0}  /* max 1 second */);
 
-    igr_assert_eq(read_file_contents("./no-command-error/dinit-run.expected"), dinit_p.get_stdout());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/no-command-error/dinit-run.expected"), dinit_p.get_stdout());
 }
 
 void add_rm_dep_test()
 {
     // Tests for adding/removing dependencies at run time
     igr_test_setup setup("add-rm-dep");
+    std::string socket_path = setup.prep_socket_path();
 
     dinit_proc dinit_p;
-    dinit_p.start("add-rm-dep", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q", "main"}, true);
+    dinit_p.start("add-rm-dep", {"-u", "-d", "sd", "-p", socket_path, "-q", "main"}, true);
 
     // "main" and "secondary" should both be running
     dinitctl_proc dinitctl_p;
-    dinitctl_p.start("add-rm-dep", {"-p", igr_dinit_socket_path, "list"});
+    dinitctl_p.start("add-rm-dep", {"-p", socket_path, "list"});
     dinitctl_p.wait_for_term({1, 0}); /* max 1 second */
-    igr_assert_eq(read_file_contents("./add-rm-dep/expected1"), dinitctl_p.get_stdout());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/add-rm-dep/expected1"), dinitctl_p.get_stdout());
 
     // remove dependency from main to secondary
-    dinitctl_p.start("add-rm-dep", {"-p", igr_dinit_socket_path, "rm-dep", "waits-for", "main", "secondary"});
+    dinitctl_p.start("add-rm-dep", {"-p", socket_path, "rm-dep", "waits-for", "main", "secondary"});
     dinitctl_p.wait_for_term({1, 0}); /* max 1 second */
-    igr_assert_eq(read_file_contents("./add-rm-dep/expected2"), dinitctl_p.get_stdout());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/add-rm-dep/expected2"), dinitctl_p.get_stdout());
 
     // "secondary" should stop as a result
-    dinitctl_p.start("add-rm-dep", {"-p", igr_dinit_socket_path, "list"});
+    dinitctl_p.start("add-rm-dep", {"-p", socket_path, "list"});
     dinitctl_p.wait_for_term({1, 0}); /* max 1 second */
-    igr_assert_eq(read_file_contents("./add-rm-dep/expected3"), dinitctl_p.get_stdout());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/add-rm-dep/expected3"), dinitctl_p.get_stdout());
 
     // re-add the dependency
-    dinitctl_p.start("add-rm-dep", {"-p", igr_dinit_socket_path, "add-dep", "waits-for", "main", "secondary"});
+    dinitctl_p.start("add-rm-dep", {"-p", socket_path, "add-dep", "waits-for", "main", "secondary"});
     dinitctl_p.wait_for_term({1, 0}); /* max 1 second */
-    igr_assert_eq(read_file_contents("./add-rm-dep/expected4"), dinitctl_p.get_stdout());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/add-rm-dep/expected4"), dinitctl_p.get_stdout());
 
     // re-adding won't affect "secondary", it remains stopped (soft dependency)
-    dinitctl_p.start("add-rm-dep", {"-p", igr_dinit_socket_path, "list"});
+    dinitctl_p.start("add-rm-dep", {"-p", socket_path, "list"});
     dinitctl_p.wait_for_term({1, 0}); /* max 1 second */
-    igr_assert_eq(read_file_contents("./add-rm-dep/expected3"), dinitctl_p.get_stdout());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/add-rm-dep/expected3"), dinitctl_p.get_stdout());
 
     // It should be possible to "wake" the "secondary" service since it has a soft dependent
-    dinitctl_p.start("add-rm-dep", {"-p", igr_dinit_socket_path, "wake", "secondary"});
+    dinitctl_p.start("add-rm-dep", {"-p", socket_path, "wake", "secondary"});
     dinitctl_p.wait_for_term({1, 0}); /* max 1 second */
-    igr_assert_eq(read_file_contents("./add-rm-dep/expected5"), dinitctl_p.get_stdout());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/add-rm-dep/expected5"), dinitctl_p.get_stdout());
 
     // Check final state of services (same as original state)
-    dinitctl_p.start("add-rm-dep", {"-p", igr_dinit_socket_path, "list"});
+    dinitctl_p.start("add-rm-dep", {"-p", socket_path, "list"});
     dinitctl_p.wait_for_term({1, 0}); /* max 1 second */
-    igr_assert_eq(read_file_contents("./add-rm-dep/expected1"), dinitctl_p.get_stdout());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/add-rm-dep/expected1"), dinitctl_p.get_stdout());
 }
 
 void var_subst_test()
 {
     // Tests for variable substitution
     igr_test_setup setup("var-subst");
+    std::string socket_path = setup.prep_socket_path();
 
     setup.prep_output_file("args-record");
 
@@ -566,7 +586,7 @@ void var_subst_test()
     igr_env_var_setup env_test_var_three("TEST_VAR_THREE", "varthree");
 
     dinit_proc dinit_p;
-    dinit_p.start("var-subst", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q", "checkargs"}, false);
+    dinit_p.start("var-subst", {"-u", "-d", "sd", "-p", socket_path, "-q", "checkargs"}, false);
     int status = dinit_p.wait_for_term({1, 0}); /* max 1 second */
     igr_assert(WIFEXITED(status) && WEXITSTATUS(status) == 0, "dinit did not exit cleanly");
 
@@ -578,38 +598,43 @@ void svc_start_fail_test()
 {
     // Tests for service start failure
     igr_test_setup setup("svc-start-fail");
+    std::string socket_path = setup.prep_socket_path();
 
     dinit_proc dinit_p;
-    dinit_p.start("svc-start-fail", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q"}, true);
+    dinit_p.start("svc-start-fail", {"-u", "-d", "sd", "-p", socket_path, "-q"}, true);
 
     dinitctl_proc dinitctl_p;
-    dinitctl_p.start("svc-start-fail",{"-u", "-p", igr_dinit_socket_path, "start", "bad-command"});
+    dinitctl_p.start("svc-start-fail",{"-u", "-p", socket_path, "start", "bad-command"});
     int status = dinitctl_p.wait_for_term({1, 0}); /* max 1 second */
 
     igr_assert(WIFEXITED(status) && WEXITSTATUS(status) == 1, "dinitctl did not return error code");
-    igr_assert_eq(read_file_contents("./svc-start-fail/expected-1"), dinitctl_p.get_stdout());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/svc-start-fail/expected-1"),
+            dinitctl_p.get_stdout());
 
-    dinitctl_p.start("svc-start-fail",{"-u", "-p", igr_dinit_socket_path, "start", "timeout-command"});
+    dinitctl_p.start("svc-start-fail",{"-u", "-p", socket_path, "start", "timeout-command"});
     status = dinitctl_p.wait_for_term({2, 0}); /* max 2 seconds */
 
     igr_assert(WIFEXITED(status) && WEXITSTATUS(status) == 1, "dinitctl did not return error code");
-    igr_assert_eq(read_file_contents("./svc-start-fail/expected-2"), dinitctl_p.get_stdout());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/svc-start-fail/expected-2"),
+            dinitctl_p.get_stdout());
     igr_assert_eq("", dinitctl_p.get_stderr());
 }
 
 void dep_not_found_test()
 {
     igr_test_setup setup("dep-not-found");
+    std::string socket_path = setup.prep_socket_path();
 
     dinit_proc dinit_p;
-    dinit_p.start("dep-not-found", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q"}, true);
+    dinit_p.start("dep-not-found", {"-u", "-d", "sd", "-p", socket_path, "-q"}, true);
 
     dinitctl_proc dinitctl_p;
-    dinitctl_p.start("svc-start-fail", {"-u", "-p", igr_dinit_socket_path, "start", "missing-dep-svc"});
+    dinitctl_p.start("svc-start-fail", {"-u", "-p", socket_path, "start", "missing-dep-svc"});
     int status = dinitctl_p.wait_for_term({1, 0}); /* max 1 second */
 
     igr_assert(WIFEXITED(status) && WEXITSTATUS(status) == 1, "dinitctl did not return error code");
-    igr_assert_eq(read_file_contents("./dep-not-found/output.expected"), dinitctl_p.get_stderr());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/dep-not-found/output.expected"),
+            dinitctl_p.get_stderr());
     igr_assert_eq("", dinitctl_p.get_stdout());
 }
 
@@ -629,9 +654,10 @@ void pseudo_cycle_test()
     // This should not be considered a cyclic dependency. The service script should run.
 
     std::string output_file = setup.prep_output_file("svc-script");
+    std::string socket_path = setup.prep_socket_path();
 
     dinit_proc dinit_p;
-    dinit_p.start("pseudo-cycle", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q"}, true);
+    dinit_p.start("pseudo-cycle", {"-u", "-d", "sd", "-p", socket_path, "-q"}, true);
     int status = dinit_p.wait_for_term({1, 0}); /* max 1 second */
     igr_assert(WIFEXITED(status) && WEXITSTATUS(status) == 0, "dinit did not exit cleanly");
 
@@ -644,13 +670,14 @@ void before_after_test()
     igr_test_setup setup("before-after");
 
     std::string script_output_file = setup.prep_output_file("script-output");
+    std::string socket_path = setup.prep_socket_path();
 
     dinit_proc dinit_p;
-    dinit_p.start("before-after", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q"}, true);
+    dinit_p.start("before-after", {"-u", "-d", "sd", "-p", socket_path, "-q"}, true);
 
     // start parent; should start service2 and then service1 (due to before= in service2).
     dinitctl_proc dinitctl_p;
-    dinitctl_p.start("before-after", {"-u", "-p", igr_dinit_socket_path, "start", "parent"});
+    dinitctl_p.start("before-after", {"-u", "-p", socket_path, "start", "parent"});
     int status = dinitctl_p.wait_for_term({5, 0}); /* max 5 seconds */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
@@ -662,23 +689,23 @@ void before_after_test()
         throw std::system_error(errno, std::generic_category(), std::string("unlink: ") + script_output_file);
     }
 
-    dinitctl_p.start("before-after", {"-u", "-p", igr_dinit_socket_path, "stop", "parent"});
+    dinitctl_p.start("before-after", {"-u", "-p", socket_path, "stop", "parent"});
     status = dinitctl_p.wait_for_term({5, 0}); /* max 5 seconds */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
-    dinitctl_p.start("before-after", {"-u", "-p", igr_dinit_socket_path, "unload", "parent"});
+    dinitctl_p.start("before-after", {"-u", "-p", socket_path, "unload", "parent"});
     status = dinitctl_p.wait_for_term({5, 0}); /* max 5 seconds */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
-    dinitctl_p.start("before-after", {"-u", "-p", igr_dinit_socket_path, "unload", "service2"});
+    dinitctl_p.start("before-after", {"-u", "-p", socket_path, "unload", "service2"});
     status = dinitctl_p.wait_for_term({5, 0}); /* max 5 seconds */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
-    dinitctl_p.start("before-after", {"-u", "-p", igr_dinit_socket_path, "reload", "service2"});
+    dinitctl_p.start("before-after", {"-u", "-p", socket_path, "reload", "service2"});
     status = dinitctl_p.wait_for_term({5, 0}); /* max 5 seconds */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
-    dinitctl_p.start("before-after", {"-u", "-p", igr_dinit_socket_path, "start", "parent"});
+    dinitctl_p.start("before-after", {"-u", "-p", socket_path, "start", "parent"});
     status = dinitctl_p.wait_for_term({5, 0}); /* max 5 seconds */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
@@ -692,22 +719,22 @@ void before_after_test()
     status = dinit_p.wait_for_term({5, 0}); /* max 5 seconds */
     igr_assert(status == 0, "dinit did not exit cleanly");
 
-    dinit_p.start("before-after", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q"}, true);
+    dinit_p.start("before-after", {"-u", "-d", "sd", "-p", socket_path, "-q"}, true);
 
     // load without loading parent: force service2 loaded first
-    dinitctl_p.start("before-after", {"-u", "-p", igr_dinit_socket_path, "reload", "service2"});
+    dinitctl_p.start("before-after", {"-u", "-p", socket_path, "reload", "service2"});
     status = dinitctl_p.wait_for_term({5, 0}); /* max 5 seconds */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
-    dinitctl_p.start("before-after", {"-u", "-p", igr_dinit_socket_path, "reload", "service1"});
+    dinitctl_p.start("before-after", {"-u", "-p", socket_path, "reload", "service1"});
     status = dinitctl_p.wait_for_term({5, 0}); /* max 5 seconds */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
-    dinitctl_p.start("before-after", {"-u", "-p", igr_dinit_socket_path, "start", "--no-wait", "service1"});
+    dinitctl_p.start("before-after", {"-u", "-p", socket_path, "start", "--no-wait", "service1"});
     status = dinitctl_p.wait_for_term({5, 0}); /* max 5 seconds */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
-    dinitctl_p.start("before-after", {"-u", "-p", igr_dinit_socket_path, "start", "service2"});
+    dinitctl_p.start("before-after", {"-u", "-p", socket_path, "start", "service2"});
     status = dinitctl_p.wait_for_term({5, 0}); /* max 5 seconds */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
@@ -718,30 +745,31 @@ void before_after2_test()
 {
     // Tests around before/after link functionality
     igr_test_setup setup("before-after2");
+    std::string socket_path = setup.prep_socket_path();
 
     std::string script_output_file = setup.prep_output_file("script-output");
 
     dinit_proc dinit_p;
-    dinit_p.start("before-after2", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q"}, true);
+    dinit_p.start("before-after2", {"-u", "-d", "sd", "-p", socket_path, "-q"}, true);
 
     // service2 depends on service1, and service1 is "before" service2
     dinitctl_proc dinitctl_p;
-    dinitctl_p.start("before-after2", {"-u", "-p", igr_dinit_socket_path, "reload", "service2"});
+    dinitctl_p.start("before-after2", {"-u", "-p", socket_path, "reload", "service2"});
     int status = dinitctl_p.wait_for_term({5, 0}); /* max 5 seconds */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
     // Remove the depends-on dependency from service2 to service1
-    dinitctl_p.start("before-after2", {"-u", "-p", igr_dinit_socket_path, "rm-dep", "need", "service2", "service1"});
+    dinitctl_p.start("before-after2", {"-u", "-p", socket_path, "rm-dep", "need", "service2", "service1"});
     status = dinitctl_p.wait_for_term({5, 0}); /* max 5 seconds */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
     // Start both service1 and service2; service1 takes longer to start, but the "before" should prevent
     // service2 from starting until service2 has started
-    dinitctl_p.start("before-after2", {"-u", "-p", igr_dinit_socket_path, "start", "--no-wait", "service1"});
+    dinitctl_p.start("before-after2", {"-u", "-p", socket_path, "start", "--no-wait", "service1"});
     status = dinitctl_p.wait_for_term({5, 0}); /* max 5 seconds */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
-    dinitctl_p.start("before-after2", {"-u", "-p", igr_dinit_socket_path, "start", "service2"});
+    dinitctl_p.start("before-after2", {"-u", "-p", socket_path, "start", "service2"});
     status = dinitctl_p.wait_for_term({5, 0}); /* max 5 seconds */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
@@ -753,20 +781,21 @@ void log_via_pipe_test()
     igr_test_setup setup("log-via-pipe");
 
     std::string logged_output_file = setup.prep_output_file("logged-output");
+    std::string socket_path = setup.prep_socket_path();
 
     dinit_proc dinit_p;
-    dinit_p.start("log-via-pipe", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q"}, true);
+    dinit_p.start("log-via-pipe", {"-u", "-d", "sd", "-p", socket_path, "-q"}, true);
 
     nanosleepx(0, 1000000000u / 10u);
 
     igr_assert_eq(read_file_contents(logged_output_file), "");
 
     dinitctl_proc dinitctl_p;
-    dinitctl_p.start("log-via-pipe", {"-u", "-p", igr_dinit_socket_path, "start", "producer"});
+    dinitctl_p.start("log-via-pipe", {"-u", "-p", socket_path, "start", "producer"});
     int status = dinitctl_p.wait_for_term({1, 0}); /* max 1 second */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
-    dinitctl_p.start("log-via-pipe", {"-u", "-p", igr_dinit_socket_path, "stop", "producer"});
+    dinitctl_p.start("log-via-pipe", {"-u", "-p", socket_path, "stop", "producer"});
     status = dinitctl_p.wait_for_term({1, 0}); /* max 1 second */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
@@ -774,11 +803,11 @@ void log_via_pipe_test()
 
     igr_assert_eq(read_file_contents(logged_output_file), "Producing output...\n");
 
-    dinitctl_p.start("log-via-pipe", {"-u", "-p", igr_dinit_socket_path, "start", "producer"});
+    dinitctl_p.start("log-via-pipe", {"-u", "-p", socket_path, "start", "producer"});
     status = dinitctl_p.wait_for_term({1, 0}); /* max 1 second */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
-    dinitctl_p.start("log-via-pipe", {"-u", "-p", igr_dinit_socket_path, "stop", "producer"});
+    dinitctl_p.start("log-via-pipe", {"-u", "-p", socket_path, "stop", "producer"});
     status = dinitctl_p.wait_for_term({1, 0}); /* max 1 second */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
@@ -790,17 +819,18 @@ void log_via_pipe_test()
 void catlog_test()
 {
     igr_test_setup setup("catlog");
+    std::string socket_path = setup.prep_socket_path();
 
     dinit_proc dinit_p;
-    dinit_p.start("catlog", {"-u", "-d", "sd", "-p", igr_dinit_socket_path, "-q"}, true);
+    dinit_p.start("catlog", {"-u", "-d", "sd", "-p", socket_path, "-q"}, true);
 
     // wait until "output" has actually started
     dinitctl_proc dinitctl_p;
-    dinitctl_p.start("catlog", {"-u", "-p", igr_dinit_socket_path, "start", "output"});
+    dinitctl_p.start("catlog", {"-u", "-p", socket_path, "start", "output"});
     int status = dinitctl_p.wait_for_term({1, 0}); /* max 1 second */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
-    dinitctl_p.start("catlog", {"-u", "-p", igr_dinit_socket_path, "catlog", "output"});
+    dinitctl_p.start("catlog", {"-u", "-p", socket_path, "catlog", "output"});
     status = dinitctl_p.wait_for_term({1, 0}); /* max 1 second */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
@@ -808,7 +838,7 @@ void catlog_test()
 
     // Check output again, this time also clear the buffer
 
-    dinitctl_p.start("catlog", {"-u", "-p", igr_dinit_socket_path, "catlog", "--clear", "output"});
+    dinitctl_p.start("catlog", {"-u", "-p", socket_path, "catlog", "--clear", "output"});
     status = dinitctl_p.wait_for_term({1, 0}); /* max 1 second */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
@@ -816,7 +846,7 @@ void catlog_test()
 
     // Check a third time, buffer should be clear now
 
-    dinitctl_p.start("catlog", {"-u", "-p", igr_dinit_socket_path, "catlog", "--clear", "output"});
+    dinitctl_p.start("catlog", {"-u", "-p", socket_path, "catlog", "--clear", "output"});
     status = dinitctl_p.wait_for_term({1, 0}); /* max 1 second */
     igr_assert(status == 0, "dinitctl did not exit cleanly");
 
@@ -839,8 +869,8 @@ void offline_enable_test()
     }
 
     mkdir(sd_dir.c_str(), S_IRWXU);
-    cp_file("./offline-enable/sd/A", (sd_dir + "/A").c_str());
-    cp_file("./offline-enable/sd/boot", (sd_dir + "/boot").c_str());
+    cp_file((igr_input_basedir + "/offline-enable/sd/A").c_str(), (sd_dir + "/A").c_str());
+    cp_file((igr_input_basedir + "/offline-enable/sd/boot").c_str(), (sd_dir + "/boot").c_str());
     mkdir((sd_dir + "/boot.d").c_str(), S_IRWXU);
 
     // run_dinitctl $QUIET --offline -d "$IGR_OUTPUT/sd" enable A
@@ -875,14 +905,14 @@ void xdg_config_test()
     igr_test_setup setup("xdg-config");
 
     std::string ran_marker_file = setup.prep_output_file("basic-ran");
+    std::string socket_path = setup.prep_socket_path();
 
-    std::string cwd = get_full_cwd();
-    std::string config_dir = cwd + "/xdg-config/config";
+    std::string config_dir = igr_input_basedir + "/xdg-config/config";
 
     igr_env_var_setup env_output("XDG_CONFIG_HOME", config_dir.c_str());
 
     dinit_proc dinit_p;
-    dinit_p.start("xdg-config", {"-u", "-p", igr_dinit_socket_path, "-q", "basic"}, false);
+    dinit_p.start("xdg-config", {"-u", "-p", socket_path, "-q", "basic"}, false);
     dinit_p.wait_for_term({1, 0}); /* max 1 second */
 
     igr_assert_eq("ran\n", read_file_contents(ran_marker_file));
@@ -892,8 +922,10 @@ void cycles_test()
 {
     igr_test_setup setup("cycles");
 
+    std::string socket_path = setup.prep_socket_path();
+
     dinit_proc dinit_p;
-    dinit_p.start("cycles", {"-u", "-p", igr_dinit_socket_path, "-d", "sd", "-q"}, true);
+    dinit_p.start("cycles", {"-u", "-p", socket_path, "-d", "sd", "-q"}, true);
 
     // "after"-cycle:
     //  ac depends-on ac1, ac2
@@ -901,35 +933,37 @@ void cycles_test()
     //  ac2 is "after" ac1
 
     dinitctl_proc dinitctl_p;
-    dinitctl_p.start("cycles", {"-u", "-p", igr_dinit_socket_path, "start", "ac"});
+    dinitctl_p.start("cycles", {"-u", "-p", socket_path, "start", "ac"});
     int status = dinitctl_p.wait_for_term({1, 0}); /* max 1 second */
     igr_assert(status != 0, "dinitctl unexpectedly exited cleanly");
 
-    igr_assert_eq(read_file_contents("cycles/expected-ac"), dinitctl_p.get_stderr());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/cycles/expected-ac"), dinitctl_p.get_stderr());
 
     // before-after conflict:
     //  ba depends on ba1, ba2
     //  ba2 is both before and after ba1
 
-    dinitctl_p.start("cycles", {"-u", "-p", igr_dinit_socket_path, "start", "ba"});
+    dinitctl_p.start("cycles", {"-u", "-p", socket_path, "start", "ba"});
     status = dinitctl_p.wait_for_term({1, 0}); /* max 1 second */
     igr_assert(status != 0, "dinitctl unexpectedly exited cleanly");
 
-    igr_assert_eq(read_file_contents("cycles/expected-ba"), dinitctl_p.get_stderr());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/cycles/expected-ba"), dinitctl_p.get_stderr());
 
     // "before_self" is before itself
 
-    dinitctl_p.start("cycles", {"-u", "-p", igr_dinit_socket_path, "start", "before_self"});
+    dinitctl_p.start("cycles", {"-u", "-p", socket_path, "start", "before_self"});
     status = dinitctl_p.wait_for_term({1, 0}); /* max 1 second */
     igr_assert(status != 0, "dinitctl unexpectedly exited cleanly");
 
-    igr_assert_eq(read_file_contents("cycles/expected-before_self"), dinitctl_p.get_stderr());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/cycles/expected-before_self"),
+            dinitctl_p.get_stderr());
 
     // "after_self" is after itself
 
-    dinitctl_p.start("cycles", {"-u", "-p", igr_dinit_socket_path, "start", "after_self"});
+    dinitctl_p.start("cycles", {"-u", "-p", socket_path, "start", "after_self"});
     status = dinitctl_p.wait_for_term({1, 0}); /* max 1 second */
     igr_assert(status != 0, "dinitctl unexpectedly exited cleanly");
 
-    igr_assert_eq(read_file_contents("cycles/expected-after_self"), dinitctl_p.get_stderr());
+    igr_assert_eq(read_file_contents(igr_input_basedir + "/cycles/expected-after_self"),
+            dinitctl_p.get_stderr());
 }

--- a/src/igr-tests/igr-runner.cc
+++ b/src/igr-tests/igr-runner.cc
@@ -10,7 +10,7 @@
 #include <sys/types.h>
 
 #include "igr.h"
-#include "../../build/includes/mconfig.h"
+#include "mconfig.h"
 
 extern char **environ;
 

--- a/src/igr-tests/igr.h
+++ b/src/igr-tests/igr.h
@@ -14,6 +14,9 @@ std::string dinit_bindir;
 // directory for all test output (each test under a named subdir)
 std::string igr_output_basedir;
 
+// directory for all test input files
+std::string igr_input_basedir;
+
 // A pair of name, function for keeping test names along with their function
 struct test
 {
@@ -285,7 +288,7 @@ public:
             args.insert(args.begin(), "--ready-fd");
         }
 
-        igr_proc::start(wdir, (dinit_bindir + "/dinit").c_str(), args);
+        igr_proc::start((igr_input_basedir + wdir).c_str(), (dinit_bindir + "/dinit").c_str(), args);
 
         if (with_ready_wait) {
             while (ready_pipe_ptr->get_output().empty()) {
@@ -304,7 +307,7 @@ public:
 
     void start(const char *wdir, std::vector<std::string> args = {})
     {
-        igr_proc::start(wdir, (dinit_bindir + "/dinitctl").c_str(), args);
+        igr_proc::start((igr_input_basedir + wdir).c_str(), (dinit_bindir + "/dinitctl").c_str(), args);
     }
 };
 
@@ -317,7 +320,8 @@ public:
 
     void start(const char *wdir, std::vector<std::string> args = {})
     {
-        igr_proc::start(wdir, (dinit_bindir + "/dinitcheck").c_str(), args, true /* combine stdout/err */);
+        igr_proc::start((igr_input_basedir + wdir).c_str(), (dinit_bindir + "/dinitcheck").c_str(), args,
+                true /* combine stdout/err */);
     }
 };
 
@@ -357,6 +361,16 @@ public:
                     std::string("unlink " + full_filename));
         }
         return full_filename;
+    }
+
+    std::string prep_socket_path()
+    {
+        std::string full_socket_path = output_dir + "/" + "dinit.socket";
+        if (unlink(full_socket_path.c_str()) == -1 && errno != ENOENT) {
+            throw std::system_error(errno, std::generic_category(),
+                    std::string("unlink " + full_socket_path));
+        }
+        return full_socket_path;
     }
 };
 

--- a/src/igr-tests/igr.h
+++ b/src/igr-tests/igr.h
@@ -14,6 +14,12 @@ std::string dinit_bindir;
 // directory for all test output (each test under a named subdir)
 std::string igr_output_basedir;
 
+// A pair of name, function for keeping test names along with their function
+struct test
+{
+    const char *name;
+    void (*func)();
+};
 
 // exception to be thrown on failure
 class igr_failure_exc

--- a/src/igr-tests/meson.build
+++ b/src/igr-tests/meson.build
@@ -1,190 +1,31 @@
 # Included from top-level meson.build
 
 igr_tests_env += [
-     'IGR_OUTPUT_BASE=@0@'.format(meson.current_build_dir()),
-     'DEBUG=yes'
+    'IGR_OUTPUT_BASE=@0@'.format(meson.current_build_dir()),
+    'IGR_INPUT_BASE=@0@'.format(meson.current_source_dir())
 ]
 
-# Integration tests
-basic_test_script = files(meson.current_source_dir() + '/basic/run-test.sh')
-environ_test_script = files(meson.current_source_dir() + '/environ/run-test.sh')
-environ2_test_script = files(meson.current_source_dir() + '/environ2/run-test.sh')
-psenviron_test_script = files(meson.current_source_dir() + '/ps-environ/run-test.sh')
-chainto_test_script = files(meson.current_source_dir() + '/chain-to/run-test.sh')
-forcestop_test_script = files(meson.current_source_dir() + '/force-stop/run-test.sh')
-restart_test_script = files(meson.current_source_dir() + '/restart/run-test.sh')
-checkbasic_test_script = files(meson.current_source_dir() + '/check-basic/run-test.sh')
-checkcycle_test_script = files(meson.current_source_dir() + '/check-cycle/run-test.sh')
-checkcycle2_test_script = files(meson.current_source_dir() + '/check-cycle2/run-test.sh')
-checklint_test_script = files(meson.current_source_dir() + '/check-lint/run-test.sh')
-reload1_test_script = files(meson.current_source_dir() + '/reload1/run-test.sh')
-reload2_test_script = files(meson.current_source_dir() + '/reload2/run-test.sh')
-nocommanderror_test_script = files(meson.current_source_dir() + '/no-command-error/run-test.sh')
-addrmdep_test_script = files(meson.current_source_dir() + '/add-rm-dep/run-test.sh')
-varsubst_test_script = files(meson.current_source_dir() + '/var-subst/run-test.sh')
-svcstartfail_test_script = files(meson.current_source_dir() + '/svc-start-fail/run-test.sh')
-depnotfound_test_script = files(meson.current_source_dir() + '/dep-not-found/run-test.sh')
-pseudocycle_test_script = files(meson.current_source_dir() + '/pseudo-cycle/run-test.sh')
-beforeafter_test_script = files(meson.current_source_dir() + '/before-after/run-test.sh')
-beforeafter2_test_script = files(meson.current_source_dir() + '/before-after2/run-test.sh')
-logviapipe_test_script = files(meson.current_source_dir() + '/log-via-pipe/run-test.sh')
-catlog_test_script = files(meson.current_source_dir() + '/catlog/run-test.sh')
-offlineenable_test_script = files(meson.current_source_dir() + '/offline-enable/run-test.sh')
-xdgconfig_test_script = files(meson.current_source_dir() + '/xdg-config/run-test.sh')
-cycles_test_script = files(meson.current_source_dir() + '/cycles/run-test.sh')
-test(
-     'basic',
-     basic_test_script,
-     env: igr_tests_env,
-     suite: 'igr_tests'
+runner = executable(
+    'igr-runner',
+    'igr-runner.cc',
+    include_directories: '../../dasynq/include',
+    install: false
 )
-test(
-     'environ',
-     environ_test_script,
-     env: igr_tests_env,
-     suite: 'igr_tests'
-)
-test(
-     'environ2',
-     environ2_test_script,
-     env: igr_tests_env,
-     suite: 'igr_tests'
-)
-test(
-     'ps-environ',
-     psenviron_test_script,
-     env: igr_tests_env,
-     suite: 'igr_tests'
-)
-test(
-     'chain-to',
-     chainto_test_script,
-     env: igr_tests_env,
-     suite: 'igr_tests'
-)
-test(
-     'force-stop',
-     forcestop_test_script,
-     env: igr_tests_env,
-     suite: 'igr_tests'
-)
-test(
-     'restart',
-     restart_test_script,
-     env: igr_tests_env,
-     suite: 'igr_tests'
-)
-test(
-     'check-basic',
-     checkbasic_test_script,
-     env: igr_tests_env,
-     suite: 'igr_tests'
-)
-test(
-     'check-cycle',
-     checkcycle_test_script,
-     env: igr_tests_env,
-     suite: 'igr_tests'
-)
-test(
-     'check-cycle2',
-     checkcycle2_test_script,
-     env: igr_tests_env,
-     suite: 'igr_tests'
-)
-test(
-     'check-lint',
-     checklint_test_script,
-     env: igr_tests_env,
-     suite: 'igr_tests'
-)
-test(
-     'reload1',
-     reload1_test_script,
-     env: igr_tests_env,
-     suite: 'igr_tests'
-)
-test(
-     'reload2',
-     reload2_test_script,
-     env: igr_tests_env,
-     suite: 'igr_tests'
-)
-test(
-     'no-command-error',
-     nocommanderror_test_script,
-     env: igr_tests_env,
-     suite: 'igr_tests'
-)
-test(
-     'add-rm-dep',
-     addrmdep_test_script,
-     env: igr_tests_env,
-     suite: 'igr_tests'
-)
-test(
-     'var-subst',
-     varsubst_test_script,
-     env: igr_tests_env,
-     suite: 'igr_tests'
-)
-test(
-     'svc-start-fail',
-     svcstartfail_test_script,
-     env: igr_tests_env,
-     suite: 'igr_tests'
-)
-test(
-     'dep-not-found',
-     depnotfound_test_script,
-     env: igr_tests_env,
-     suite: 'igr_tests'
-)
-test(
-     'pseudo-cycle',
-     pseudocycle_test_script,
-     env: igr_tests_env,
-     suite: 'igr_tests'
-)
-test(
-     'before-after',
-     beforeafter_test_script,
-     env: igr_tests_env,
-     suite: 'igr_tests'
-)
-test(
-     'before-after2',
-     beforeafter2_test_script,
-     env: igr_tests_env,
-     suite: 'igr_tests'
-)
-test(
-    'log-via-pipe',
-    logviapipe_test_script,
-    env: igr_tests_env,
-    suite: 'igr_tests'
-)
-test(
-    'catlog',
-    catlog_test_script,
-    env: igr_tests_env,
-    suite: 'igr_tests'
-)
-test(
-    'offline-enable',
-    offlineenable_test_script,
-    env: igr_tests_env,
-    suite: 'igr_tests'
-)
-test(
-    'xdg-config',
-    xdgconfig_test_script,
-    env: igr_tests_env,
-    suite: 'igr_tests'
-)
-test(
-    'cycles',
-    cycles_test_script,
-    env: igr_tests_env,
-    suite: 'igr_tests'
-)
+
+tests = [
+    'basic', 'environ', 'environ2', 'ps-environ', 'chain-to', 'force-stop', 'restart',
+    'check-basic', 'check-cycle', 'check-cycle2', 'check-lint', 'reload1', 'reload2',
+    'no-command-error', 'add-rm-dep', 'var-subst', 'svc-start-fail', 'dep-not-found',
+    'pseudo-cycle', 'before-after', 'before-after2', 'log-via-pipe', 'catlog',
+    'offline-enable', 'xdg-config', 'cycles'
+]
+
+foreach test: tests
+    test(
+        test,
+        runner,
+        args: test,
+        env: igr_tests_env,
+        suite: 'igr_tests'
+    )
+endforeach

--- a/src/igr-tests/meson.build
+++ b/src/igr-tests/meson.build
@@ -8,7 +8,7 @@ igr_tests_env += [
 runner = executable(
     'igr-runner',
     'igr-runner.cc',
-    include_directories: '../../dasynq/include',
+    include_directories: include_directories('../../dasynq/include', '../..'),
     install: false
 )
 


### PR DESCRIPTION
Hi.

Summary of changes:
1. `igr_dinit_socket_path` is removed and `socket_path` should be prepared for each test to avoid any race condition instead.
2. Added ability to run a single test to support meson tests wrapper.
3. Any path from source (such as expected results) should use `igr_base_basedir` which is set by meson (default values are for Make based runtime).

For meson igr-tests, I decide to stay with manual list but it's now really simple to add new test, Just add name of test to a list and everything will work out-of-box.

Fixes #302

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>` 