### PR TITLE
Add newline escaping support

### DIFF
--- a/doc/manpages/dinit-service.5.m4
+++ b/doc/manpages/dinit-service.5.m4
@@ -133,7 +133,8 @@ The quote characters are not considered part of the property value.
 White space appearing inside quotes does not act as a delimiter for tokens.
 .IP \(bu
 A backslash (\\) can be used to escape the next character, causing it to
-lose any special meaning and become part of the property value.
+lose any special meaning and become part of the property value (escaped newlines are an
+exception; they mark the end of a comment, and are treated as a unescaped space).
 A double backslash (\\\\) is collapsed to a single backslash within the parameter value.
 White space preceded by a backslash will not separate tokens.
 .LP

--- a/src/includes/load-service.h
+++ b/src/includes/load-service.h
@@ -758,6 +758,7 @@ void process_service_file(string name, std::istream &service_file, T func)
     while (getline(service_file, line)) {
         unsigned line_num_after = ++line_num;
 
+        if (line.empty()) continue;
         while (line.back() == '\\') {
             string nextline;
             string::iterator j;

--- a/src/tests/loadtests.cc
+++ b/src/tests/loadtests.cc
@@ -27,6 +27,24 @@ void test_basic()
     assert(t1->get_name() == "t1");
 }
 
+void test_newline()
+{
+    dirload_service_set sset(test_service_dir.c_str());
+    bp_sys::setenv("arg", "t3", true);
+    auto t3 = static_cast<base_process_service *>(sset.load_service("t3"));
+    auto exec_parts = t3->get_exec_arg_parts();
+    assert(t3->get_type() == service_type_t::PROCESS);
+    assert(strcmp(exec_parts[0], "command1") == 0);
+    assert(strcmp(exec_parts[1], "t3") == 0);
+    assert(strcmp(exec_parts[2], "arg1") == 0);
+    assert(strcmp(exec_parts[3], "command2") == 0);
+    assert(strcmp(exec_parts[4], "t3") == 0);
+    assert(strcmp(exec_parts[5], "arg2") == 0);
+    assert(strcmp(exec_parts[6], "command3") == 0);
+    assert(strcmp(exec_parts[7], "t3") == 0);
+    assert(strcmp(exec_parts[8], "arg3") == 0);
+}
+
 void test_env_subst()
 {
     dirload_service_set sset(test_service_dir.c_str());
@@ -328,6 +346,7 @@ int main(int argc, char **argv)
     RUN_TEST(test_env_subst, "            ");
     RUN_TEST(test_env_subst2, "           ");
     RUN_TEST(test_env_subst3, "           ");
+    RUN_TEST(test_newline, "              ");
     RUN_TEST(test_nonexistent, "          ");
     RUN_TEST(test_settings, "             ");
     RUN_TEST(test_path_env_subst, "       ");

--- a/src/tests/test-services/t3
+++ b/src/tests/test-services/t3
@@ -1,0 +1,6 @@
+command = command1 $arg arg1 \
+  # insert info about command2 here\
+  command2 $arg arg2\
+  command3 $arg # insert info about command3 here\
+  arg3
+type = process


### PR DESCRIPTION
A few alternative options are possible (such appending the newline literally and handling them in `read_setting_value` , or translating it into a space) but this is likely what most people, coming from the shell, expect.

Closes: https://github.com/davmac314/dinit/issues/291