### PR TITLE
igr-runner: Make sure "Failed" line ends with a newline

### DIFF
--- a/src/igr-tests/igr-runner.cc
+++ b/src/igr-tests/igr-runner.cc
@@ -144,6 +144,8 @@ int main(int argc, char **argv)
         std::cout << " XXX";
     }
 
+    std::cout << std::endl;
+
     return failed == 0 ? 0 : 1;
 }
 


### PR DESCRIPTION
To avoid such case:
...
Test run finished.
Passed: 26
Failed: 0make[2]: Leaving directory '/__w/dinit/dinit/src/igr-tests' make[1]: Leaving directory '/__w/dinit/dinit/src'
...

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`