### PR TITLE
control: Don't call process_packet() when bad_conn_closed is set

### DIFF
--- a/src/control.cc
+++ b/src/control.cc
@@ -1445,7 +1445,7 @@ bool control_conn_t::data_ready() noexcept
     // complete packet?
     while (rbuf.get_length() >= chklen) {
         try {
-            if (!process_packet()) {
+            if (!process_packet() || bad_conn_close) {
                 return false;
             }
         }

--- a/src/tests/test-includes/dinit.h
+++ b/src/tests/test-includes/dinit.h
@@ -134,12 +134,18 @@ class eventloop_t
 
     class bidi_fd_watcher
     {
+        int watch_flags = -1;
         int watched_fd = -1;
 
         public:
         void set_watches(eventloop_t &eloop, int newFlags) noexcept
         {
+            watch_flags = newFlags;
+        }
 
+        int get_watches(eventloop_t &eloop) noexcept
+        {
+            return watch_flags;
         }
 
         void add_watch(eventloop_t &eloop, int fd, int flags, int inprio = dasynq::DEFAULT_PRIORITY,
@@ -150,6 +156,7 @@ class eventloop_t
             }
             eloop.regd_bidi_watchers[fd] = this;
             watched_fd = fd;
+            watch_flags = flags;
         }
 
         int get_watched_fd() noexcept


### PR DESCRIPTION
[CWE-835: Loop with Unreachable Exit Condition ('Infinite Loop')](https://cwe.mitre.org/data/definitions/835.html)

Sending garbage data and then closing the connection could lead into out-of-memory. Because after closing the connection, Dinit will stuck in `(rbuf.get_length() >= chklen)` while loop and then the outbuf buffer is used because the connection fd is not available anymore. This triggers the OOM detector in the fuzzer and can result in segfault when Dinit is used as init of system.

It's mostly harmless because triggering it requires root or particular user (the user who starts dinit) access. See https://github.com/davmac314/dinit/blob/master/doc/SECURITY

Firstly detected in https://github.com/davmac314/dinit/actions/runs/7233843212

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`