### PR TITLE
cptests/Makefile: Don't rebuild test objects that were built by primary tests

### DIFF
--- a/src/tests/cptests/Makefile
+++ b/src/tests/cptests/Makefile
@@ -14,13 +14,10 @@ build-tests: cptests
 run-tests: cptests
 	./cptests
 
-cptests: cptests.o $(parent_objs) $(parent_test_objs)
-	$(CXX) -o cptests cptests.o $(parent_test_objects) $(parent_objs) $(ALL_TEST_LDFLAGS)
+cptests: cptests.o $(parent_objs:%=../%) $(parent_test_objects)
+	$(CXX) -o cptests cptests.o $(parent_test_objects) $(parent_objs:%=../%) $(ALL_TEST_LDFLAGS)
 
 $(objects): %.o: %.cc
-	$(CXX) $(ALL_TEST_CXXFLAGS) -MMD -MP -I../test-includes -I../../../dasynq/include -I../../../build/includes -I../../includes -c $< -o $@
-
-$(parent_objs): %.o: ../../%.cc
 	$(CXX) $(ALL_TEST_CXXFLAGS) -MMD -MP -I../test-includes -I../../../dasynq/include -I../../../build/includes -I../../includes -c $< -o $@
 
 clean:


### PR DESCRIPTION
We already have `parent_objs` built in `../` directory with exactly same compiler flags. So why we don't use them in cptests also instead of building them again?

This also should improve build time.

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`