### PR TITLE
igr-tests/Makefile: Include "CPPFLAGS" in igr-runner compile process

### DIFF
--- a/src/igr-tests/Makefile
+++ b/src/igr-tests/Makefile
@@ -5,7 +5,7 @@ check-igr: igr-runner
 	IGR_OUTPUT_BASE=$$PWD/igr-output ./igr-runner
 
 igr-runner: igr-runner.cc igr.h
-	$(CXX) $(CXXFLAGS) $(CXXFLAGS_EXTRA) -I../../dasynq/include -I../../build/includes $(LDFLAGS) $(LDFLAGS_EXTRA) igr-runner.cc -o igr-runner
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(CXXFLAGS_EXTRA) -I../../dasynq/include -I../../build/includes $(LDFLAGS) $(LDFLAGS_EXTRA) igr-runner.cc -o igr-runner
 
 clean:
 	rm -f igr-runner


### PR DESCRIPTION
It should be there, I guess.

I was testing Dinit on NetBSD with `./configure CXX=clang++ CPPFLAGS="-DDASYNQ_HAVE_KQUEUE=1"` (and it was really awesome) that found out the `CPPFLAGS` is not applied in igr-runner compile process.

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`