### PR TITLE
CI: meson_ci.yml: Mark MacOS as aarch64 not amd64

### DIFF
--- a/.github/workflows/meson_ci.yml
+++ b/.github/workflows/meson_ci.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false # Upload src/igr-tests/*/output/* files in igr-tests
       matrix:
         include:
-          - arch: 'amd64'
+          - arch: 'aarch64'
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Same as #355 but for `meson_ci.yml`

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`