### PR TITLE
dinitctl: Fix wrong app name in "--services-dir" not found error message

### DIFF
--- a/src/dinitctl.cc
+++ b/src/dinitctl.cc
@@ -208,7 +208,7 @@ int dinitctl_main(int argc, char **argv)
                     service_dir_opts.set_specified_service_dir(argv[i]);
                 }
                 else {
-                    cerr << "dinitcheck: '--services-dir' (-d) requires an argument" << endl;
+                    cerr << "dinitctl: '--services-dir' (-d) requires an argument" << endl;
                     return 1;
                 }
             }


### PR DESCRIPTION
Looks like a copy-pasta error :)

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`