### PR TITLE
dinitcheck: warn about non-absolute executable path

### DIFF
--- a/src/dinitcheck.cc
+++ b/src/dinitcheck.cc
@@ -765,7 +765,11 @@ service_record *load_service(service_set_t &services, const std::string &name,
 
     auto check_command = [&](const char *setting_name, const char *command) {
         struct stat command_stat;
-        if (fstatat(dirfd, command, &command_stat, 0) == -1) {
+        if (command[0] != '/') {
+            report_service_description_err(name,
+                    std::string("executable '") + command + "' is not an absolute path");
+        }
+        else if (fstatat(dirfd, command, &command_stat, 0) == -1) {
             report_service_description_err(name,
                     std::string("could not stat ") + setting_name + " executable '" + command
                     + "': " + strerror(errno));


### PR DESCRIPTION
dinit's behavior depends on PATH environment if a service contains command with non-absolute executable path. dinitcheck may not even find correct executables in this case.

Such services may lead to security problems, systemd has been searching executables only in compilation-time specified paths. As similar features do not exist in dinit and aren't very meaningful, we just warn about dangerous usage.

References: https://www.man7.org/linux/man-pages/man5/systemd.service.5.html#COMMAND_LINES