### PR TITLE
add support for passing arguments to services

### DIFF
--- a/doc/manpages/dinit.8.m4
+++ b/doc/manpages/dinit.8.m4
@@ -119,7 +119,7 @@ Specifies the name of a service that should be started (along with its
 dependencies).
 If none are specified, defaults to \fIboot\fR (which requires that a suitable service description
 for the \fIboot\fR service exists). Multiple services can be specified in which case they will each
-be started.
+be started. An argument to the service may be included here.
 .sp
 \fBNote:\fR on Linux, if \fBdinit\fR is running as PID 1 and with UID 0, it may ignore "naked"
 service names (without preceding \fB\-\-service\fR/\fB\-t\fR) provided on the command line.

--- a/doc/manpages/dinitctl.8.m4
+++ b/doc/manpages/dinitctl.8.m4
@@ -163,6 +163,7 @@ Clear the log buffer for the service after displaying it.
 .TP
 \fIservice-name\fR
 Specifies the name of the service to which the command applies.
+It may have an argument that is passed to the service.
 .\"
 .SH COMMAND DESCRIPTIONS
 .\"

--- a/src/dinitcheck.cc
+++ b/src/dinitcheck.cc
@@ -671,7 +671,7 @@ service_record *load_service(service_set_t &services, const std::string &name,
             };
 
             try {
-                process_service_line(settings, name.c_str(), line, input_pos, setting, op, i, end,
+                process_service_line(settings, name.c_str(), nullptr, line, input_pos, setting, op, i, end,
                         load_service_n, process_dep_dir_n);
             }
             catch (service_description_exc &exc) {
@@ -745,7 +745,7 @@ service_record *load_service(service_set_t &services, const std::string &name,
         return resolve_env_var(name, envmap);
     };
 
-    settings.finalise(report_err, renvmap, report_err, resolve_var);
+    settings.finalise(report_err, renvmap, nullptr, report_err, resolve_var);
 
     if (!settings.working_dir.empty()) {
         service_wdir = settings.working_dir;

--- a/src/igr-tests/svc-arg/checkarg.sh
+++ b/src/igr-tests/svc-arg/checkarg.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "$1" >> "$OUTPUT"

--- a/src/igr-tests/svc-arg/sd/checkarg
+++ b/src/igr-tests/svc-arg/sd/checkarg
@@ -1,0 +1,4 @@
+type = process
+waits-for = checkarg2@$1
+command = ../checkarg.sh $1
+restart = false

--- a/src/igr-tests/svc-arg/sd/checkarg2
+++ b/src/igr-tests/svc-arg/sd/checkarg2
@@ -1,0 +1,3 @@
+type = scripted
+waits-for = checkarg3@hello
+command = ../checkarg.sh $1

--- a/src/igr-tests/svc-arg/sd/checkarg3
+++ b/src/igr-tests/svc-arg/sd/checkarg3
@@ -1,0 +1,3 @@
+type = scripted
+waits-for = checkarg4@test-$1
+command = ../checkarg.sh $1

--- a/src/igr-tests/svc-arg/sd/checkarg4
+++ b/src/igr-tests/svc-arg/sd/checkarg4
@@ -1,0 +1,3 @@
+type = scripted
+waits-for = checkarg5@test-$$1
+command = ../checkarg.sh $1

--- a/src/igr-tests/svc-arg/sd/checkarg5
+++ b/src/igr-tests/svc-arg/sd/checkarg5
@@ -1,0 +1,2 @@
+type = scripted
+command = ../checkarg.sh $1

--- a/src/includes/load-service.h
+++ b/src/includes/load-service.h
@@ -1556,9 +1556,8 @@ void process_service_line(settings_wrapper &settings, const char *name, string &
         }
         case setting_id_t::DEPENDS_MS_D:
         {
-            string dependency_name = read_setting_value(input_pos, i, end);
-            settings.depends.emplace_back(load_service(dependency_name.c_str()),
-                    dependency_type::MILESTONE);
+            string depends_ms_d = read_setting_value(input_pos, i, end);
+            process_dep_dir(settings.depends, depends_ms_d, dependency_type::MILESTONE);
             break;
         }
         case setting_id_t::AFTER:


### PR DESCRIPTION
The argument is a part of the full service name always. Therefore, each argument instantiation is a separate instance of the service, with separate loading.

The following cases are supported:

1) passing the argument to any `dinitctl` command that takes an a service name
2) dependencies with an argument
2) using the argument in any context that does variable substitution
3) using the argument in dependency arguments (performing a restricted version of variable substitution)

documentation is updated, load+integration tests are updated/added

while at it, i found that depends-ms.d was being parsed wrong (it was never reading the dir) so i fixed that too