### PR TITLE
Implement listening on activation environment changes

### DIFF
--- a/doc/manpages/dinit-monitor.8.m4
+++ b/doc/manpages/dinit-monitor.8.m4
@@ -1,7 +1,7 @@
 changequote(`@@@',`$$$')dnl
 @@@.TH DINIT\-MONITOR "8" "$$$MONTH YEAR@@@" "Dinit $$$VERSION@@@" "Dinit \- service management system"
 .SH NAME
-dinit\-monitor \- monitor services supervised by Dinit
+dinit\-monitor \- monitor services or environment supervised by Dinit
 .\"
 .SH SYNOPSIS
 .\"
@@ -9,15 +9,17 @@ dinit\-monitor \- monitor services supervised by Dinit
 .nh
 .HP
 .B dinit-monitor
-[\fIoptions\fR] {\fB\-c\fR \fIcommand\fR, \fB\-\-command\fR \fIcommand\fR} \fIservice-name\fR [\fIservice-name\fR...]
+[\fIoptions\fR] {\fB\-c\fR \fIcommand\fR, \fB\-\-command\fR \fIcommand\fR} \fIservice-or-env\fR [\fIservice-or-env\fR...]
 .\"
 .PD
 .hy
 .\"
 .SH DESCRIPTION
 .\"
-\fBdinit\-monitor\fR is a utility to monitor the state of one or more services managed by the \fBdinit\fR daemon.
-Changes in service state are reported by the execution of the specified command.
+\fBdinit\-monitor\fR is a utility to monitor the state of one or more services or environment managed by the \fBdinit\fR daemon.
+Changes in service or environment state are reported by the execution of the specified command.
+When monitoring environment, positional arguments are not required (all environment will be monitored).
+By default, service events are monitored.
 .\"
 .SH GENERAL OPTIONS
 .TP
@@ -27,6 +29,11 @@ Display brief help text and then exit.
 \fB\-\-version\fR
 Display version and then exit.
 .TP
+\fB\-e\fR, \fB\-\-exit\fR
+Exit after the first command is executed, instead of waiting for more events.
+\fB\-E\fR, \fB\-\-env\fR
+Instead of monitoring the services, monitor changes in the global environment.
+If no environment variables are passed, all environment is monitored.
 \fB\-s\fR, \fB\-\-system\fR
 Control the system init process (this is the default when run as root).
 This option determines the default path to the control socket used to communicate with the \fBdinit\fR daemon
@@ -38,8 +45,8 @@ This option determines the default path to the control socket used to communicat
 (it does not override the \fB\-p\fR option).
 .TP
 \fB\-i\fR, \fB\-\-initial\fR
-Issue the specified command additionally for the initial status of the services (when \fBdinit\-monitor\fR is started).
-Without this option, the command is only executed whenever service status changes.
+Issue the specified command additionally for the initial status of the services or environment (when \fBdinit\-monitor\fR is started).
+Without this option, the command is only executed whenever status changes.
 .TP
 \fB\-\-str\-started\fR \fIstarted-text\fR
 Specify the text used for the substitution of the status in the command (as specified
@@ -53,6 +60,14 @@ by the \fB\-\-command\fR option) when a service stops.
 Specify the text used for the substitution of the status in the command (as specified
 by the \fB\-\-command\fR option) when a service fails to start.
 .TP
+\fB\-\-str\-set\fR \fIset-text\fR
+Specify the text used for the substitution of the status in the command (as specified
+by the \fB\-\-command\fR option) when an environment variable is set.
+.TP
+\fB\-\-str\-unset\fR \fIunset-text\fR
+Specify the text used for the substitution of the status in the command (as specified
+by the \fB\-\-command\fR option) when an environment variable is unset.
+.TP
 \fB\-\-socket\-path\fR \fIsocket-path\fR, \fB\-p\fR \fIsocket-path\fR
 Specify the path to the socket used for communicating with the service manager daemon.
 When not specified, the \fIDINIT_SOCKET_PATH\fR environment variable is read, otherwise
@@ -61,9 +76,11 @@ Dinit's default values are used.
 .SH STATUS REPORT OPTIONS
 .TP
 \fB\-\-command\fR \fIcommand\fR, \fB\-c\fR \fIcommand\fR
-Execute the specified \fIcommand\fR when the service status changes. In \fIcommand\fR, \fB%n\fR
-will be substituted with the service name and \fB%s\fR will be substituted with a textual
-description of the new status (\fBstarted\fR, \fBstopped\fR or \fBfailed\fR). A double percent sign
+Execute the specified \fIcommand\fR when the service status changes.
+In \fIcommand\fR, \fB%n\fR will be substituted with the service or environment variable name,
+\fB%v\fR will be substituted with the environment variable value, and \fB%s\fR will be substituted
+with a textual description of the new status (\fBstarted\fR, \fBstopped\fR or \fBfailed\fR for
+services, \fBset\fR or \fBunset\fR for environment variables). A double percent sign
 (\fB%%\fR) is substituted with a single percent sign character.
 .\"
 .SH OPERATION

--- a/doc/manpages/dinitctl.8.m4
+++ b/doc/manpages/dinitctl.8.m4
@@ -69,6 +69,9 @@ dinitctl \- control services supervised by Dinit
 [\fIoptions\fR] \fBsetenv\fR [\fIname\fR[=\fIvalue\fR] \fI...\fR]
 .HP
 .B dinitctl
+[\fIoptions\fR] \fBunsetenv\fR [\fIname\fR \fI...\fR]
+.HP
+.B dinitctl
 [\fIoptions\fR] \fBcatlog\fR [\fB--clear\fR] \fIservice-name\fR
 .HP
 .B dinitctl
@@ -321,6 +324,10 @@ The value can be provided on the command line or retrieved from the environment 
 called in.
 Any subsequently started or restarted service will have these environment variables available.
 This is particularly useful for user services that need access to session information.
+.TP
+\fBunsetenv\fR
+Unset one or more variables in the activation environment.
+Any subsequently started or restarted service will have these environment variables unset.
 .TP
 \fBcatlog\fR
 Show the contents of the log buffer for the named service.

--- a/src/control.cc
+++ b/src/control.cc
@@ -18,7 +18,7 @@ using namespace dinit_cptypes;
 namespace {
     // Control protocol minimum compatible version and current version:
     constexpr uint16_t min_compat_version = 1;
-    constexpr uint16_t cp_version = 4;
+    constexpr uint16_t cp_version = 5;
 
     // check for value in a set
     template <typename T, int N, typename U>

--- a/src/igr-tests/environ/setenv.sh
+++ b/src/igr-tests/environ/setenv.sh
@@ -9,7 +9,7 @@ case "$1" in
         fi
         ;;
     setenv2)
-        if [ "$FOO" = "foo" ]; then
+        if [ "$FOO" = "foo" -a -z "$BAR" ]; then
             echo 2 >> "$OUTPUT"
             export BAR=bar
             "$DINITCTL" -p "$SOCKET" setenv BAR BAZ=baz
@@ -17,6 +17,7 @@ case "$1" in
         ;;
     setenv3)
         "$DINITCTL" -p "$SOCKET" setenv FOO=foo
+        "$DINITCTL" -p "$SOCKET" unsetenv BAR
         echo 3 >> "$OUTPUT"
         ;;
     *) ;;

--- a/src/igr-tests/igr-runner.cc
+++ b/src/igr-tests/igr-runner.cc
@@ -175,6 +175,7 @@ void environ_test()
     igr_env_var_setup env_output("OUTPUT", output_file.c_str());
     igr_env_var_setup env_socket("SOCKET", socket_path.c_str());
     igr_env_var_setup env_dinitctl("DINITCTL", (dinit_bindir + "/dinitctl").c_str());
+    igr_env_var_setup env_bar("BAR", "to_be_unset");
 
     dinit_proc dinit_p;
     dinit_p.start("environ", {"-u", "-d", "sd", "-p", socket_path, "-q", "-e", "environment1", "checkenv"});

--- a/src/includes/control-cmds.h
+++ b/src/includes/control-cmds.h
@@ -11,7 +11,7 @@
 // 3 - dinit 0.17.1 (adds QUERYSERVICEDSCDIR)
 // 4 - dinit 0.18.0 (adds CLOSEHANDLE, GETALLENV)
 // 5 - (unreleased) (process status now represented as ([int]si_code + [int]si_status) rather than
-//                   a single integer; SERVICEEVENT5 sent alongside SERVICEEVENT)
+//                   a single integer; SERVICEEVENT5 sent alongside SERVICEEVENT; adds LISTENENV, ENVEVENT)
 
 // Requests:
 enum class cp_cmd : dinit_cptypes::cp_cmd_t {
@@ -87,6 +87,9 @@ enum class cp_cmd : dinit_cptypes::cp_cmd_t {
 
     // Query status of an individual service (5+)
     SERVICESTATUS5 = 26,
+
+    // Start listening to environment events
+    LISTENENV = 27,
 };
 
 // Replies:
@@ -175,6 +178,8 @@ enum class cp_info : dinit_cptypes::cp_info_t {
     SERVICEEVENT = 100,
     // Service event for protocol version 5+ - 4 byte handle, 1 byte event code, proc_status_t status
     SERVICEEVENT5 = 101,
+    // Environment event; 2 bytes length + env string
+    ENVEVENT = 102,
 };
 
 #endif

--- a/src/includes/control.h
+++ b/src/includes/control.h
@@ -12,6 +12,7 @@
 
 #include <dinit.h>
 #include <dinit-log.h>
+#include <dinit-env.h>
 #include <control-cmds.h>
 #include <service-listener.h>
 #include <cpbuffer.h>
@@ -81,7 +82,7 @@ class control_conn_watcher : public eventloop_t::bidi_fd_watcher_impl<control_co
     }
 };
 
-class control_conn_t : private service_listener
+class control_conn_t : private service_listener, private env_listener
 {
     friend rearm control_conn_cb(eventloop_t *loop, control_conn_watcher *watcher, int revents);
     friend class control_conn_t_test;
@@ -190,6 +191,9 @@ class control_conn_t : private service_listener
     // Get the complete environment
     bool process_getallenv();
 
+    // Listen to environment events
+    bool process_listenenv();
+
     // Notify that data is ready to be read from the socket. Returns true if the connection should
     // be closed.
     bool data_ready() noexcept;
@@ -226,6 +230,9 @@ class control_conn_t : private service_listener
     // Note that this can potentially be called during packet processing (upon issuing
     // service start/stop orders etc).
     void service_event(service_record *service, service_event_t event) noexcept final override;
+
+    // Process environment event broadcast.
+    void environ_event(environment *env, std::string const &var_and_val, bool overridden) noexcept final override;
     
     public:
     control_conn_t(eventloop_t &loop, service_set * services_p, int fd)


### PR DESCRIPTION
This implements a protocol that lets a connection to the control socket listen on changes in the global environment issued by `dinitctl setenv`. This opens up a range of possibilities - such as special services that trigger other services when an environment variable appears.

It also implements a `dinit-monitor` environment watching mode as a proof of functionality, though likely not acceptable as is (likely at least the `string_view` will need getting rid of?)

I intentionally did not implement things like protocol checking and whatnot yet since I want your feedback first.

I should probably also change the protocol a bit - at very least, the envevent should contain information about whether the envvar is newly created or if it overwrites a previous one.

Let me know what you think :)