### PR TITLE
Fix status filling for new protocol

### DIFF
--- a/src/control.cc
+++ b/src/control.cc
@@ -754,7 +754,7 @@ bool control_conn_t::list_services5()
             pkt_buf[0] = (char)cp_rply::SVCINFO;
             pkt_buf[1] = nameLen;
 
-            fill_status_buffer(&pkt_buf[2], sptr);
+            fill_status_buffer5(&pkt_buf[2], sptr);
 
             for (int i = 0; i < nameLen; i++) {
                 pkt_buf[hdrsize+i] = name[i];
@@ -834,7 +834,7 @@ bool control_conn_t::process_service_status5()
     std::vector<char> pkt_buf(2 + STATUS_BUFFER5_SIZE);
     pkt_buf[0] = (char)cp_rply::SERVICESTATUS;
     pkt_buf[1] = 0;
-    fill_status_buffer(pkt_buf.data() + 2, service);
+    fill_status_buffer5(pkt_buf.data() + 2, service);
 
     return queue_packet(std::move(pkt_buf));
 }

--- a/src/dinitctl.cc
+++ b/src/dinitctl.cc
@@ -2378,7 +2378,7 @@ static int cat_service_log(int socknum, cpbuffer_t &rbuffer, const char *service
         cout << flush;
 
         bool trailing_nl = false;
-        char output_buf[rbuffer.get_size()];
+        char output_buf[cpbuffer_t::get_size()];
         while (bufsize > 0) {
             unsigned l = rbuffer.get_length();
             if (l == 0) {


### PR DESCRIPTION
Just something I ran into while browsing the code for libdinitctl. This new protocol does not seem to be used at all yet because the protocol version has not been incremented to 5, but might as well not forget.