### PR TITLE
Service argument enhancements

### DIFF
--- a/doc/manpages/dinit-service.5.m4
+++ b/doc/manpages/dinit-service.5.m4
@@ -784,6 +784,8 @@ The following commands are available:
 \fB@include\fR \fIpath\fR
 Include the contents of another file, specified via its full path.
 If the specified file does not exist, an error is produced.
+The \fIpath\fR is subject to minimal variable substitution
+(see \fBVARIABLE SUBSTITUTION\fR).
 .TP
 \fB@include\-opt\fR \fIpath\fR
 As for \fB@include\fR, but produces no error if the named file does not exist.

--- a/doc/manpages/dinit-service.5.m4
+++ b/doc/manpages/dinit-service.5.m4
@@ -198,7 +198,7 @@ Specifies a file containing value assignments for environment variables, in the 
 format recognised by the \fBdinit\fR command's \fB\-\-env\-file\fR option (see \fBdinit\fR(8)).
 The file is read when the service is loaded, therefore values from it can be used in variable
 substitutions (see \fBVARIABLE SUBSTITUTION\fR).
-Variable substitution is not performed on the \fBenv\-file\fR property value itself.
+Minimal variable substitution is performed on the \fBenv\-file\fR property value itself.
 If the path is not absolute, it is resolved relative to the directory containing the service
 description.
 .TP

--- a/src/igr-tests/igr-runner.cc
+++ b/src/igr-tests/igr-runner.cc
@@ -995,5 +995,6 @@ void svc_arg_test()
             "test-hello\n" +
             "hello\n" +
             "foo\n" +
-            "foo\n");
+            "foo\n" +
+            "bar\n");
 }

--- a/src/igr-tests/svc-arg/checkarg.sh
+++ b/src/igr-tests/svc-arg/checkarg.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
 
 echo "$1" >> "$OUTPUT"
+
+if [ -n "$FOOVAR" ]; then
+    echo "$FOOVAR" >> "$OUTPUT"
+fi

--- a/src/igr-tests/svc-arg/sd/checkarg
+++ b/src/igr-tests/svc-arg/sd/checkarg
@@ -2,3 +2,6 @@ type = process
 waits-for = checkarg2@$1
 command = ../checkarg.sh $1
 restart = false
+# this normally only supports absolute paths,
+# but here we control it so just for the test...
+@include-opt sd/inc-$1

--- a/src/igr-tests/svc-arg/sd/env-foo
+++ b/src/igr-tests/svc-arg/sd/env-foo
@@ -1,0 +1,1 @@
+FOOVAR=bar

--- a/src/igr-tests/svc-arg/sd/inc-foo
+++ b/src/igr-tests/svc-arg/sd/inc-foo
@@ -1,0 +1,1 @@
+env-file = env-foo

--- a/src/includes/load-service.h
+++ b/src/includes/load-service.h
@@ -1092,9 +1092,9 @@ static void value_var_subst(const char *setting_name, std::string &line,
                 if (name.empty()) {
                     throw service_description_exc(setting_name, "invalid/missing variable name after '$'");
                 }
-                else if (is_arg && (name != "1" || !argval)) {
-                    // only one arg is supported and it must be present
-                    throw service_description_exc(setting_name, "missing value in argument substitution");
+                else if (is_arg && name != "1") {
+                    // only one arg is supported
+                    throw service_description_exc(setting_name, "only one service argument may be present");
                 }
                 char altmode = '\0';
                 bool colon = false;
@@ -1132,10 +1132,16 @@ static void value_var_subst(const char *setting_name, std::string &line,
                     if (!resolved || (colon && !*resolved)) {
                         resolved_vw = {line.c_str() + (altbeg - line.begin()), (size_t)(altend - altbeg)};
                     }
-                } else if (altmode == '+') {
+                }
+                else if (altmode == '+') {
                     if (resolved && (!colon || *resolved)) {
                         resolved_vw = {line.c_str() + (altbeg - line.begin()), (size_t)(altend - altbeg)};
                     }
+                }
+                else if (is_arg && !argval) {
+                    // $1 and ${1} is special in that it must be set or it is an error
+                    // however, we want the more complex syntaxes for conditional substitution
+                    throw service_description_exc(setting_name, "missing value in argument substitution");
                 }
 
                 xpos = j - line.begin();

--- a/src/includes/load-service.h
+++ b/src/includes/load-service.h
@@ -1238,8 +1238,8 @@ static void value_var_subst(const char *setting_name, std::string &line,
     line = std::move(r_line);
 }
 
-// Reads a dependency name while performing minimal argument expansion in it.
-inline string read_dependency_value(const char *setting_name, file_pos_ref input_pos, string_iterator &i,
+// Reads a value while performing minimal argument expansion in it.
+inline string read_value_with_arg(const char *setting_name, file_pos_ref input_pos, string_iterator &i,
         string_iterator end, const char *argval)
 {
     string rval;
@@ -1537,7 +1537,7 @@ void process_service_line(settings_wrapper &settings, const char *name, const ch
             settings.working_dir = read_setting_value(input_pos, i, end, nullptr);
             break;
         case setting_id_t::ENV_FILE:
-            settings.env_file = read_setting_value(input_pos, i, end, nullptr);
+            settings.env_file = read_value_with_arg(setting.c_str(), input_pos, i, end, arg);
             break;
         #if SUPPORT_CGROUPS
         case setting_id_t::RUN_IN_CGROUP:
@@ -1575,21 +1575,21 @@ void process_service_line(settings_wrapper &settings, const char *name, const ch
             break;
         case setting_id_t::DEPENDS_ON:
         {
-            string dependency_name = read_dependency_value(setting.c_str(), input_pos, i, end, arg);
+            string dependency_name = read_value_with_arg(setting.c_str(), input_pos, i, end, arg);
             settings.depends.emplace_back(load_service(dependency_name.c_str()),
                     dependency_type::REGULAR);
             break;
         }
         case setting_id_t::DEPENDS_MS:
         {
-            string dependency_name = read_dependency_value(setting.c_str(), input_pos, i, end, arg);
+            string dependency_name = read_value_with_arg(setting.c_str(), input_pos, i, end, arg);
             settings.depends.emplace_back(load_service(dependency_name.c_str()),
                     dependency_type::MILESTONE);
             break;
         }
         case setting_id_t::WAITS_FOR:
         {
-            string dependency_name = read_dependency_value(setting.c_str(), input_pos, i, end, arg);
+            string dependency_name = read_value_with_arg(setting.c_str(), input_pos, i, end, arg);
             settings.depends.emplace_back(load_service(dependency_name.c_str()),
                     dependency_type::WAITS_FOR);
             break;
@@ -1614,13 +1614,13 @@ void process_service_line(settings_wrapper &settings, const char *name, const ch
         }
         case setting_id_t::AFTER:
         {
-            string after_name = read_dependency_value(setting.c_str(), input_pos, i, end, arg);
+            string after_name = read_value_with_arg(setting.c_str(), input_pos, i, end, arg);
             settings.after_svcs.emplace_back(std::move(after_name));
             break;
         }
         case setting_id_t::BEFORE:
         {
-            string before_name = read_dependency_value(setting.c_str(), input_pos, i, end, arg);
+            string before_name = read_value_with_arg(setting.c_str(), input_pos, i, end, arg);
             settings.before_svcs.emplace_back(std::move(before_name));
             break;
         }

--- a/src/load-service.cc
+++ b/src/load-service.cc
@@ -523,7 +523,7 @@ service_record * dirload_service_set::load_reload_service(const char *fullname, 
 
             process_service_line(settings, name.c_str(), argval, line, fpr, setting,
                     op, i, end, load_service_n, process_dep_dir_n);
-        });
+        }, argval);
 
         auto report_err = [&](const char *msg){
             throw service_load_exc(name, msg);


### PR DESCRIPTION
This changes 3 things:

1) The meta-commands now resolve the service argument. This is useful to set different fields depending on the argument value (by including separate per-arg-value file)
2) The env-file path itself performs minimal expansion (so you can include different env-files depending on the value of the argument)
3) Make it possible to have a service that only optionally takes an argument by using the substitution syntax that takes default values instead of always erroring. The syntaxes without a value will still error.