### PR TITLE
init: optionally load the system SELinux policy

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -180,6 +180,9 @@ DEFAULT_STOP_TIMEOUT=XXX
     this, its process group is sent a SIGKILL signal which should cause it to terminate immediately.
     The default if unspecified is 10 seconds. (The value can be overridden for individual services
     via the service description).
+SUPPORT_SELINUX=1|0
+    Whether to build support for loading the system SELinux policy at boot (Linux only).
+    See doc/linux/SELINUX.md for more information.
 SUPPORT_CGROUPS=1|0
     Whether to include support for cgroups (Linux only).
 SUPPORT_CAPABILITIES=1|0

--- a/BUILD_MESON
+++ b/BUILD_MESON
@@ -168,6 +168,11 @@ Custom options:
                              Available values : enabled, disabled, auto
                              Default value : auto
 
+ support-selinux           : Whether to build support for loading the system SELinux policy at boot
+                             (Linux only). See doc/linux/SELinux.md for more information.
+                             Available values : enabled, disabled, auto
+                             Default value : auto
+
 
 Running the test suite
 =-=-=-=-=-=-=-=-=-=-=-

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -17,3 +17,4 @@ The following people (in alphabetical order) have contributed:
  * Oliver Amann - Code, testing, documentation
  * Locria Cyber - Code, documentation
  * q66 - Code, testing, documentation.
+ * Rahul Sandhu - Code

--- a/build/Makefile
+++ b/build/Makefile
@@ -19,7 +19,8 @@ includes/mconfig.h: ../mconfig tools/mconfig-gen.cc version.conf
 		$(if $(SUPPORT_IOPRIO),SUPPORT_IOPRIO=$(SUPPORT_IOPRIO),) \
 		$(if $(SUPPORT_OOM_ADJ),SUPPORT_OOM_ADJ=$(SUPPORT_OOM_ADJ),) \
 		$(if $(USE_UTMPX),USE_UTMPX=$(USE_UTMPX),) \
-		$(if $(USE_INITGROUPS),USE_INITGROUPS=$(USE_INITGROUPS),) > includes/mconfig.h
+		$(if $(USE_INITGROUPS),USE_INITGROUPS=$(USE_INITGROUPS),) \
+		$(if $(SUPPORT_SELINUX),SUPPORT_SELINUX=$(SUPPORT_SELINUX),) > includes/mconfig.h
 
 clean:
 	rm -f includes/mconfig.h

--- a/build/mconfig.mesontemplate
+++ b/build/mconfig.mesontemplate
@@ -8,6 +8,7 @@
 #mesondefine USE_UTMPX
 #mesondefine USE_INITGROUPS
 #mesondefine SUPPORT_CGROUPS
+#mesondefine SUPPORT_SELINUX
 #mesondefine SUPPORT_CAPABILITIES
 #mesondefine SUPPORT_IOPRIO
 #mesondefine SUPPORT_OOM_ADJ

--- a/build/tools/mconfig-gen.cc
+++ b/build/tools/mconfig-gen.cc
@@ -89,6 +89,9 @@ int main(int argc, char **argv)
     if (vars.find("DEFAULT_AUTO_RESTART") != vars.end()) {
         cout << "#define DEFAULT_AUTO_RESTART " << vars["DEFAULT_AUTO_RESTART"] << "\n";
     }
+    if (vars.find("SUPPORT_SELINUX") != vars.end()) {
+        cout << "#define SUPPORT_SELINUX " << vars["SUPPORT_SELINUX"] << "\n";
+    }
 
     cout << "\n// Constants\n";
     cout << "\nconstexpr static char DINIT_VERSION[] = " << stringify(vars["VERSION"]) << ";\n";

--- a/configure
+++ b/configure
@@ -213,6 +213,8 @@ Optional options:
   --enable-initgroups               Enable initialization of supplementary groups for run-as
                                     [Enabled]
   --disable-initgroups              Disable initialization of supplementary groups for run-as
+  --enable-selinux                  Enable SELinux support [Disabled]
+  --disable-selinux                 Disable SELinux support
   --enable-auto-restart             Enable auto-restart for services by default (Deprecated;
                                     use --default-auto-restart=...)
   --disable-auto-restart            Disable auto-restart for services by default (Deprecated;
@@ -283,6 +285,7 @@ for var in PREFIX \
            SUPPORT_OOM_ADJ \
            USE_UTMPX \
            USE_INITGROUPS \
+           SUPPORT_SELINUX \
            SYSCONTROLSOCKET \
            STRIPOPTS
 do
@@ -324,6 +327,8 @@ for arg in "$@"; do
         --disable-initgroups|--enable-initgroups=no) USE_INITGROUPS=0 ;;
         --enable-auto-restart|--enable-auto-restart=yes) DEFAULT_AUTO_RESTART=ALWAYS ;; # Deprecated
         --disable-auto-restart|--enable-auto-restart=no) DEFAULT_AUTO_RESTART=NEVER ;; # Deprecated
+        --enable-selinux|--enable-selinux=yes) SUPPORT_SELINUX=1 ;;
+        --disable-selinux|--enable-selinux=no) SUPPORT_SELINUX=0 ;;
         --enable-strip|--enable-strip=yes) STRIPOPTS="-s" ;;
         --disable-strip|--enable-strip=no) STRIPOPTS="" ;;
         --default-auto-restart=never) DEFAULT_AUTO_RESTART=NEVER ;;
@@ -355,6 +360,7 @@ done
 : "${DEFAULT_START_TIMEOUT:="60"}"
 : "${DEFAULT_STOP_TIMEOUT:="10"}"
 : "${USE_INITGROUPS:="1"}"
+: "${SUPPORT_SELINUX:="0"}"
 if [ "$PLATFORM" = "Linux" ]; then
     : "${BUILD_SHUTDOWN:="yes"}"
     : "${SUPPORT_CGROUPS:="1"}"
@@ -479,6 +485,9 @@ fi
 if [ "$AUTO_LDFLAGS_BASE" = true ] && [ "$PLATFORM" = FreeBSD ]; then
     try_ld_argument LDFLAGS_BASE -lrt
 fi
+if [ "$AUTO_LDFLAGS_BASE" = true ] && [ "$SUPPORT_SELINUX" = "1" ]; then
+    try_ld_argument LDFLAGS_BASE -lselinux
+fi
 if [ "$SUPPORT_CAPABILITIES" != 0 ]; then
     if [ "$AUTO_LDFLAGS_LIBCAP" = true ]; then
         try_ld_argument LDFLAGS_LIBCAP -lcap
@@ -589,6 +598,7 @@ LDFLAGS_LIBCAP=$LDFLAGS_LIBCAP
 # Feature settings
 SUPPORT_CGROUPS=$SUPPORT_CGROUPS
 USE_INITGROUPS=$USE_INITGROUPS
+SUPPORT_SELINUX=$SUPPORT_SELINUX
 SUPPORT_CAPABILITIES=$SUPPORT_CAPABILITIES
 SUPPORT_IOPRIO=$SUPPORT_IOPRIO
 SUPPORT_OOM_ADJ=$SUPPORT_OOM_ADJ

--- a/doc/linux/SELINUX.md
+++ b/doc/linux/SELINUX.md
@@ -1,0 +1,54 @@
+# Dinit SELinux Awareness
+
+Dinit has support for basic SELinux awareness. This document is intended to outline the extent and
+inner workings of Dinit's SELinux awareness. The reader is assumed to be knowledgeable about the
+basics of [SELinux](https://github.com/SELinuxProject/selinux-notebook) and Dinit.
+
+Dinit needs to be built with SELinux support (see [BUILD](/BUILD)) to enable the features that are
+mentioned in this document.
+
+## Loading the system SELinux policy
+When running as the system init or manager, Dinit by default will attempt to load the system's
+SELinux policy and transition itself to a context specified by that policy if not already done so.
+This behaviour may be disabled by passing the `--disable-selinux-policy` command-line argument to
+`dinit`.
+
+If not already mounted earlier in the boot process (e.g. by an initramfs), Dinit will instruct the
+SELinux framework to mount sysfs (typically `/sys`), and selinuxfs (typically `/sys/fs/selinux`) in
+order to load the policy. Should the mounting of either fail, the policy load may fail. In addition,
+Dinit itself will also temporarily mount `/proc`, and the newly mounted procfs will be mounted over
+an existing procfs. In order for this, and as such the initial setup of SELinux, to succeed, the
+`/proc` directory will need to exist. This occurs before any services are started.
+
+Dependent on the requested loading state of SELinux, Dinit has different behaviour should policy
+load fail. If SELinux was requested to be loaded in Enforcing mode and the policy load failed,
+Dinit will bail early after printing an error to stderr. If SELinux was requested to be loaded in
+Permissive mode and the policy load failed, Dinit will buffer a message to be logged via Dinit's
+logging facilities once they have been initalised. Regardless of the requested loading state of
+SELinux, Dinit will always buffer a log message should transitioning itself to the correct
+context fail. Failure to transition will not result in Dinit bailing as the policy previously
+loaded may prevent Dinit from being able to do so.
+
+The following flowchart provides an overview of the process of loading the policy:
+```mermaid
+flowchart TD
+    A[Start] --> B{"Is Dinit running as the system init or manager?"}
+    B -->|Yes| C{Have we been requested to not load the SELinux policy?}
+    C -->|No| D[Continue rest of Dinit initialization]
+    C -->|Yes| E[Is the SELinux policy already loaded?]
+    E -->|Yes| D
+    E --> |No| G[Attempt to mount /proc]
+    G --> J[Attempt to load the SELinux policy]
+    J --> K{Did the SELinux policy load succeed?}
+    K -->|Yes| L[Attempt to calculate our new context and transition]
+    K -->|No| M{Was enforcing mode requested?}
+    M -->|Yes| I[Error exit early]
+    M -->|No| D
+    L --> N{Did we successfully transition?}
+    N -->|Yes| P{Did we mount /proc?}
+    N -->|No| O[Log an error]
+    O --> P
+    P -->|Yes| Q[Unmount /proc]
+    P -->|No| D
+    Q --> D
+```

--- a/doc/linux/SELINUX.md
+++ b/doc/linux/SELINUX.md
@@ -1,38 +1,35 @@
-# Dinit SELinux Awareness
+# Dinit SELinux Support
 
-Dinit has support for basic SELinux awareness. This document is intended to outline the extent and
-inner workings of Dinit's SELinux awareness. The reader is assumed to be knowledgeable about the
+Dinit has support for loading the SELinux security policy at boot time, which must be enabled at
+build time (see [BUILD](/BUILD)). This document outlines how to use this support, including the
+requirements and potential system effects. The reader is assumed to be knowledgeable about the
 basics of [SELinux](https://github.com/SELinuxProject/selinux-notebook) and Dinit.
 
-Dinit needs to be built with SELinux support (see [BUILD](/BUILD)) to enable the features that are
-mentioned in this document.
-
 ## Loading the system SELinux policy
-When running as the system init or manager, Dinit by default will attempt to load the system's
-SELinux policy and transition itself to a context specified by that policy if not already done so.
-This behaviour may be disabled by passing the `--disable-selinux-policy` command-line argument to
-`dinit`.
+When running as both the system init and system manager, Dinit by default will attempt to load the
+system's SELinux policy and transition itself to a context specified by that policy if not already
+done so. This behaviour may be disabled by passing the `--disable-selinux-policy` command line
+argument to `dinit`.
 
-If not already mounted earlier in the boot process (e.g. by an initramfs), Dinit will instruct the
+If not already mounted earlier in the boot process (e.g., by an initramfs), Dinit will instruct the
 SELinux framework to mount sysfs (typically `/sys`), and selinuxfs (typically `/sys/fs/selinux`) in
 order to load the policy. Should the mounting of either fail, the policy load may fail. In addition,
 Dinit itself will also temporarily mount `/proc`, and the newly mounted procfs will be mounted over
 an existing procfs. In order for this, and as such the initial setup of SELinux, to succeed, the
 `/proc` directory will need to exist. This occurs before any services are started.
 
-Dependent on the requested loading state of SELinux, Dinit has different behaviour should policy
-load fail. If SELinux was requested to be loaded in Enforcing mode and the policy load failed,
-Dinit will bail early after printing an error to stderr. If SELinux was requested to be loaded in
-Permissive mode and the policy load failed, Dinit will buffer a message to be logged via Dinit's
-logging facilities once they have been initalised. Regardless of the requested loading state of
-SELinux, Dinit will always buffer a log message should transitioning itself to the correct
-context fail. Failure to transition will not result in Dinit bailing as the policy previously
-loaded may prevent Dinit from being able to do so.
+Dependent on the SELinux mode of operation, Dinit has different behaviour should policy load fail.
+If the mode of operation is Enforcing mode and the policy load failed, Dinit will exit with an
+error. If the mode of operation is Permissive mode and the policy load failed, Dinit will prepare a
+message to be logged via Dinit's logging facilities once they have been initialised. Regardless of
+the SELinux mode of operation, Dinit will log a warning should transitioning itself to the correct
+context fail. Failure to transition will not result in Dinit exiting with an error; the policy that
+was just loaded may prevent Dinit from being able to transition into a new context.
 
 The following flowchart provides an overview of the process of loading the policy:
 ```mermaid
 flowchart TD
-    A[Start] --> B{"Is Dinit running as the system init or manager?"}
+    A[Start] --> B{"Is Dinit running as both the system init and system manager?"}
     B -->|Yes| C{Have we been requested to not load the SELinux policy?}
     C -->|No| D[Continue rest of Dinit initialization]
     C -->|Yes| E[Is the SELinux policy already loaded?]
@@ -41,8 +38,8 @@ flowchart TD
     G --> J[Attempt to load the SELinux policy]
     J --> K{Did the SELinux policy load succeed?}
     K -->|Yes| L[Attempt to calculate our new context and transition]
-    K -->|No| M{Was enforcing mode requested?}
-    M -->|Yes| I[Error exit early]
+    K -->|No| M{Is the SELinux mode of operation Enforcing mode?}
+    M -->|Yes| I[Exit with an error]
     M -->|No| D
     L --> N{Did we successfully transition?}
     N -->|Yes| P{Did we mount /proc?}

--- a/doc/manpages/dinit.8.m4
+++ b/doc/manpages/dinit.8.m4
@@ -113,6 +113,10 @@ If service description settings contain relative cgroup paths, they will be reso
 this path.
 This option is only available if \fBdinit\fR is built with cgroups support.
 .TP
+\fB\-\-disable\-selinux\-policy\fR
+Disable loading of the system SELinux policy.
+This option is only available if \fBdinit\fR is built with SELinux support.
+.TP
 \fB\-\-help\fR
 Display brief help text and then exit.
 .TP
@@ -297,6 +301,21 @@ kernel (or some that are, due to bugs) are passed to init via the environment ra
 There are several ways to work around this.
 Service names following the \fB\-\-container\fR (\fB\-o\fR) or \fB\-\-system\-mgr\fR (\fB\-m\fR) options are not ignored.
 Also, the \fB\-\-service\fR (\fB\-t\fR) option can be used to force a service name to be recognised regardless of operating mode.
+.\"
+.SH SELINUX SUPPORT
+.LP
+When running as the system init or manager on a SELinux enabled machine, \fBdinit\fR will by default load the system's SELinux policy.
+If \fBdinit\fR fails to load the SELinux policy when requested to do so in enforcing mode, it will log to stderr and error-exit early.
+If however permissive mode was requested, \fBdinit\fR will log a warning and proceed.
+This feature requires \fBdinit\fR to have been built with SELinux support.
+.LP
+When loading the SELinux policy, a few special filesystems may be mounted.
+The SELinux library will mount \fBsysfs\fR at \fB/sys\fR, and \fBselinuxfs\fR at \fB/sys/fs/selinux\fR if they are not already mounted.
+Unless the SELinux policy load type has been set to \fBDisabled\fR, \fB/sys/fs/selinux\fR will not be unmounted by the SELinux library.
+\fBsysfs\fR is never unmounted.
+Dinit itself will temporarily mount \fBprocfs\fR at \fB/proc\fR in order to transition itself to the context it should be started in
+per the newly loaded SELinux policy. The \fB/proc\fR directory must exist on the filesystem for this to succeed. During the period which
+Dinit has temporarily mounted \fB/proc\fR, any previously-mounted \fB/proc\fR will be mounted over.
 .\"
 .SH FILES
 .\"

--- a/meson.build
+++ b/meson.build
@@ -36,6 +36,7 @@ support_ioprio = get_option('support-ioprio')
 support_oom_adj = get_option('support-oom-adj')
 use_utmpx = get_option('use-utmpx')
 use_initgroups = get_option('use-initgroups')
+support_selinux = get_option('support-selinux')
 default_auto_restart = get_option('default-auto-restart')
 default_start_timeout = get_option('default-start-timeout').to_string()
 default_stop_timeout = get_option('default-stop-timeout').to_string()
@@ -61,6 +62,7 @@ endif
 
 ## Dependencies
 libcap_dep = dependency('libcap', required: support_capabilities)
+libselinux_dep = dependency('libselinux', version : '>= 2.1.9', required : support_selinux)
 
 ## Prepare mconfig.h
 mconfig_data.set_quoted('DINIT_VERSION', version)
@@ -71,6 +73,7 @@ mconfig_data.set('DEFAULT_AUTO_RESTART', default_auto_restart)
 mconfig_data.set('DEFAULT_START_TIMEOUT', default_start_timeout)
 mconfig_data.set('DEFAULT_STOP_TIMEOUT', default_stop_timeout)
 mconfig_data.set10('USE_INITGROUPS', use_initgroups)
+mconfig_data.set10('SUPPORT_SELINUX', libselinux_dep.found() or support_selinux.enabled())
 mconfig_data.set10('SUPPORT_CGROUPS', support_cgroups.auto() and platform == 'linux' or support_cgroups.enabled())
 mconfig_data.set10('SUPPORT_CAPABILITIES', libcap_dep.found() and not support_capabilities.disabled())
 mconfig_data.set10('SUPPORT_IOPRIO', support_ioprio.auto() and platform == 'linux' or support_ioprio.enabled())

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -109,3 +109,9 @@ option(
     value : 'auto',
     description : 'Building shutdown/reboot/soft-reboot/halt or not.'
 )
+option(
+    'support-selinux',
+    type : 'feature',
+    value : 'auto',
+    description : 'SELinux support'
+)

--- a/src/dinit-log.cc
+++ b/src/dinit-log.cc
@@ -282,16 +282,17 @@ void buffered_log_stream::watch_removed() noexcept
 
 } // end namespace
 
-// Initialise the logging subsystem
-// Potentially throws std::bad_alloc or std::system_error
-void init_log(bool syslog_format)
+void init_log(bool syslog_format) noexcept
 {
-    log_stream[DLOG_CONS].add_watch(event_loop, STDOUT_FILENO, dasynq::OUT_EVENTS, false);
-    enable_console_log(true);
-
     // The main (non-console) log won't be active yet, but we set the format here so that we
     // buffer messages in the correct format:
     log_format_syslog[DLOG_MAIN] = syslog_format;
+}
+
+void init_console_log()
+{
+    log_stream[DLOG_CONS].add_watch(event_loop, STDOUT_FILENO, dasynq::OUT_EVENTS, false);
+    enable_console_log(true);
 }
 
 void setup_log_console_handoff(service_set *sset)

--- a/src/includes/dinit-log.h
+++ b/src/includes/dinit-log.h
@@ -58,7 +58,11 @@ extern loglevel_t log_level[2];
 extern bool console_service_status;  // show service status messages to console?
 
 void enable_console_log(bool do_enable) noexcept;
-void init_log(bool syslog_format);
+// Sets the format in which to buffer messages (syslog or plain).
+void init_log(bool syslog_format) noexcept;
+// Begin outputting log messages to the console. The format should be set previously via init_log().
+// Potentially throws std::bad_alloc or std::system_error.
+void init_console_log();
 void setup_log_console_handoff(service_set *sset);
 void close_log();
 void setup_main_log(int fd);

--- a/src/meson.build
+++ b/src/meson.build
@@ -28,7 +28,7 @@ misc_args = {
     'include_directories': default_incdir,
     'install': true,
     'install_dir': sbindir,
-    'dependencies': [libcap_dep]
+    'dependencies': [libcap_dep, libselinux_dep]
 }
 
 ## src/'s defines for igr-tests/

--- a/src/tests/tests.cc
+++ b/src/tests/tests.cc
@@ -1418,6 +1418,7 @@ void test_log1()
     // Basic test that output to log is written to log file
     service_set sset;
     init_log(true /* syslog format */);
+    init_console_log();
     setup_log_console_handoff(&sset);
 
     int logfd = bp_sys::allocfd();
@@ -1445,6 +1446,7 @@ void test_log2()
     // test that log is closed on write failure.
     service_set sset;
     init_log(true /* syslog format */);
+    init_console_log();
     setup_log_console_handoff(&sset);
 
     bool was_closed = false;


### PR DESCRIPTION
Implements #399 . Currently a draft PR for some of the reasons noted in that issue. Another thing to add:
- I saw mentioned here, https://github.com/davmac314/dinit/issues/240#issuecomment-1963096377, that you don't want to be falling back to C interfaces. For now, I'm just calling `fprintf` if the SELinux policy fails to load (as `/dev/console` is likely unable to be accessed at that point). Would you prefer `std::cout` to be used for now in this case?