### PR TITLE
Implement systemd-style readiness notification via NOTIFY_SOCKET

### DIFF
--- a/src/load-service.cc
+++ b/src/load-service.cc
@@ -742,6 +742,8 @@ service_record * dirload_service_set::load_reload_service(const char *fullname, 
             rvalps->set_run_as_uid_gid(settings.run_as_uid, settings.run_as_gid);
             rvalps->set_notification_fd(settings.readiness_fd);
             rvalps->set_notification_var(std::move(settings.readiness_var));
+            rvalps->set_ready_socket_details(std::move(settings.ready_socket_path),
+                    settings.ready_socket_perms, settings.ready_socket_uid, settings.ready_socket_gid);
             rvalps->set_logfile_details(std::move(settings.logfile), settings.logfile_perms,
                     settings.logfile_uid, settings.logfile_gid);
             rvalps->set_log_buf_max(settings.max_log_buffer_sz);

--- a/src/run-child-proc.cc
+++ b/src/run-child-proc.cc
@@ -156,12 +156,16 @@ void base_process_service::run_child_proc(run_proc_params params) noexcept
             err.stage = exec_stage::SET_NOTIFYFD_VAR;
             // We need to do an allocation: the variable name length, '=', and space for the value,
             // and nul terminator:
-            int notify_var_len = strlen(notify_var);
-            int req_sz = notify_var_len + ((CHAR_BIT * sizeof(int) - 1 + 2) / 3) + 1;
-            char * var_str = (char *) malloc(req_sz);
-            if (var_str == nullptr) goto failure_out;
-            snprintf(var_str, req_sz, "%s=%d", notify_var, notify_fd);
-            service_env.set_var(var_str);
+            if (!strchr(notify_var, '=')) {
+                int notify_var_len = strlen(notify_var);
+                int req_sz = notify_var_len + ((CHAR_BIT * sizeof(int) - 1 + 2) / 3) + 1;
+                char * var_str = (char *) malloc(req_sz);
+                if (var_str == nullptr) goto failure_out;
+                snprintf(var_str, req_sz, "%s=%d", notify_var, notify_fd);
+                service_env.set_var(var_str);
+            } else {
+                service_env.set_var(notify_var);
+            }
         }
 
         // Set up Systemd-style socket activation:

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -47,6 +47,9 @@ setting_details all_settings[] = {
         {"run-as",                  setting_id_t::RUN_AS,                   false,  true,   false},
         {"chain-to",                setting_id_t::CHAIN_TO,                 false,  true,   false},
         {"ready-notification",      setting_id_t::READY_NOTIFICATION,       false,  true,   false},
+        {"ready-socket-permissions", setting_id_t::READY_SOCKET_PERMISSIONS, false, true,   false},
+        {"ready-socket-uid",        setting_id_t::READY_SOCKET_UID,         false,  true,   false},
+        {"ready-socket-gid",        setting_id_t::READY_SOCKET_GID,         false,  true,   false},
 
         // Note: inittab-_ settings are supported even if functionality is not built in
         {"inittab-id",              setting_id_t::INITTAB_ID,               false,  true,   false},


### PR DESCRIPTION
The service may specify this with ready-notification=socket. This will result in dinit creating an abstract datagram socket and perform reads on it. As soon as the READY=1 datagram arrives, the readiness notification is signaled.

Note that this is a very rough proof of concept implementation, e.g. the socket path is hardcoded and so on, I mostly just want to know your opinion on whether to do this at all or how to provide the interface and so on - once I know I should proceed and how, I will clean it up.

Also, as it is it carries a dependency on abstract sockets, which are a Linux extension. I wonder if something else should be done on other platforms, or if to make this an optional Linux-only functionality, or ...

I considered implementing this with a wrapper, but considering the mechanism uses datagram sockets and therefore there is no way to know what the lifetime of the watcher process should be, I decided not to. Doing it in dinit means the service manager knows about how long to keep the socket around.

Fixes https://github.com/davmac314/dinit/issues/310