### PR TITLE
Fix bad formatting of line number when a service fails to load

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,6 +12,7 @@ The following people (in alphabetical order) have contributed:
  * Edd Barrett - Testing, documentation.
  * Fabien Poussin - Code, services, documentation.
  * James Knippes - Code
+ * Jami Kettunen - Code
  * Mobin Aydinfar - Code, documentation, CI
  * Oliver Amann - Code, testing, documentation
  * Locria Cyber - Code, documentation

--- a/src/includes/service.h
+++ b/src/includes/service.h
@@ -223,12 +223,12 @@ inline void log_service_load_failure(service_description_exc &exc)
     if (exc.input_pos.get_line_num() != (unsigned)-1) {
         if (exc.setting_name == nullptr) {
             log(loglevel_t::ERROR, "Error in service description for '", exc.service_name,
-                    "' (file ", exc.input_pos.get_file_name(), "line ", exc.input_pos.get_line_num(), "): ",
+                    "' (file ", exc.input_pos.get_file_name(), ", line ", exc.input_pos.get_line_num(), "): ",
                     exc.exc_description);
         }
         else {
             log(loglevel_t::ERROR, "Error in service description for '", exc.service_name, "': setting '", exc.setting_name, "' "
-                    "(file ", exc.input_pos.get_file_name(), "line ", exc.input_pos.get_line_num(), "): ",
+                    "(file ", exc.input_pos.get_file_name(), ", line ", exc.input_pos.get_line_num(), "): ",
                     exc.exc_description);
         }
     }


### PR DESCRIPTION
It was adding `line X` directly after the service file path without any kind of separation. As an example the following:
```
dinit: Error in service description for 'early-test' (file /etc/dinit.d/early-testline 1): badly formed line.
dinit: Error in service description for 'early-test': setting 'options' (file /etc/dinit.d/early-testline 4): unknown option: invalid
```
would become:
```
dinit: Error in service description for 'early-test' (file /etc/dinit.d/early-test, line 1): badly formed line.
dinit: Error in service description for 'early-test': setting 'options' (file /etc/dinit.d/early-test, line 4): unknown option: invalid
```
after this change.