### PR TITLE
Draft: Misc gcc fixes

### DIFF
--- a/src/control.cc
+++ b/src/control.cc
@@ -1660,7 +1660,7 @@ bool control_conn_t::send_data() noexcept
         if (oom_close) {
             // Send oom response
             char oomBuf[] = { (char)cp_rply::OOM };
-            bp_sys::write(iob.get_watched_fd(), oomBuf, 1);
+            (void)bp_sys::write(iob.get_watched_fd(), oomBuf, 1);
         }
         return true;
     }

--- a/src/options-processing.cc
+++ b/src/options-processing.cc
@@ -33,7 +33,7 @@ void service_dir_opt::build_paths(bool am_system_init)
         /* service directory name */
         if (!am_system_init) {
             const char * xdg_config_home = getenv("XDG_CONFIG_HOME");
-            size_t xdg_config_home_len;
+            size_t xdg_config_home_len = 0;
             if (xdg_config_home != nullptr && *xdg_config_home != '\0') {
                 xdg_config_home_len = strlen(xdg_config_home);
                 if (xdg_config_home[xdg_config_home_len - 1] == '/') {


### PR DESCRIPTION
Marked as draft for now as there are probably some things that need discussing first. Fixes a few warnings when building with GCC.

For this warning:
```
[27/31] Compiling C++ object src/dinit.p/control.cc.o
../src/control.cc: In member function ‘bool control_conn_t::send_data()’:
../src/control.cc:1663:26: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
 1663 |             bp_sys::write(iob.get_watched_fd(), oomBuf, 1);
      |             ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
I'm guessing the result of bp_sys::write is being ignored as we are at an oom state anyway? I wanted to confirm that before adding a comment, and if that is a case, should I add an explanatory comment explaining why we are throwing away the result of the function?