### PR TITLE
Fix SVCDSCDIR replies on 64-bit big endian architectures

### DIFF
--- a/src/control.cc
+++ b/src/control.cc
@@ -1315,7 +1315,7 @@ bool control_conn_t::process_query_dsc_dir()
     // 4 bytes (uint32_t) = directory length (no nul terminator)
     // N bytes            = directory (no nul)
     std::vector<char> reppkt;
-    size_t sdir_len = strlen(service->get_service_dsc_dir());
+    auto sdir_len = static_cast<uint32_t>(strlen(service->get_service_dsc_dir()));
     reppkt.resize(1 + sizeof(uint32_t) + sdir_len);  // packet type, dir length, dir
     reppkt[0] = (char)cp_rply::SVCDSCDIR;
     std::memcpy(&reppkt[1], &sdir_len, sizeof(sdir_len));


### PR DESCRIPTION
While on LE this works, on BE it copies the other four bytes into the uint32_t, resulting in a zero. This in turn results in a protocol error on those architectures.