### PR TITLE
dinit-service: Do parameter substitution in consumer-of

### DIFF
--- a/doc/manpages/dinit-service.5.m4
+++ b/doc/manpages/dinit-service.5.m4
@@ -489,6 +489,8 @@ Specifies that this service consumes (as its standard input) the output of anoth
 For example, this allows this service to act as a logging agent for another service.
 The named service must be a process-based service with \fBlog\-type\fR set to \fBpipe\fR.
 This setting is only valid for \fBprocess\fR and \fBbgprocess\fR services.
+The \fIservice-name\fR is subject to pre-load variable substitution
+(see \fBVARIABLE SUBSTITUTION\fR).
 .TP
 \fBoptions\fR: \fIoption\fR...
 Specifies various options for this service. See the \fBOPTIONS\fR section.

--- a/src/igr-tests/svc-arg-consumer/scripts/consumer.sh
+++ b/src/igr-tests/svc-arg-consumer/scripts/consumer.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "$1" > "$IGR_OUTPUT/logged-output"
+cat - >> "$IGR_OUTPUT/logged-output" 2>&1

--- a/src/igr-tests/svc-arg-consumer/scripts/producer.sh
+++ b/src/igr-tests/svc-arg-consumer/scripts/producer.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "Producing output..."

--- a/src/igr-tests/svc-arg-consumer/sd/boot
+++ b/src/igr-tests/svc-arg-consumer/sd/boot
@@ -1,0 +1,2 @@
+type = internal
+waits-for = consumer@producer

--- a/src/igr-tests/svc-arg-consumer/sd/consumer
+++ b/src/igr-tests/svc-arg-consumer/sd/consumer
@@ -1,0 +1,3 @@
+type = process
+command = ../scripts/consumer.sh $1
+consumer-of = $1

--- a/src/igr-tests/svc-arg-consumer/sd/producer
+++ b/src/igr-tests/svc-arg-consumer/sd/producer
@@ -1,0 +1,3 @@
+type = scripted
+command = ../scripts/producer.sh
+log-type = pipe

--- a/src/includes/load-service.h
+++ b/src/includes/load-service.h
@@ -1946,7 +1946,8 @@ void process_service_line(settings_wrapper &settings, const char *name, const ch
         }
         case setting_id_t::CONSUMER_OF:
         {
-            string consumed_svc_name = read_setting_value(input_pos, i, end);
+            string consumed_svc_name = read_value_resolved(setting.c_str(), input_pos, i, end,
+                    service_arg, lookup_var);
             if (consumed_svc_name == name) {
                 throw service_description_exc(name, "service cannot be its own consumer", "consumer-of",
                         input_pos);


### PR DESCRIPTION
Seems useful for s6-log/vlogger based logging systems.

It includes a new test: `svc-arg-consumer`. I decide to add a new test for it instead of using `svc-arg` because of usage of `process` services, `boot` service and also dinitctl commands for testing.

Fixes #427 

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`