### PR TITLE
Add -k option to shutdown for kexec functionality

### DIFF
--- a/doc/manpages/shutdown.8.m4
+++ b/doc/manpages/shutdown.8.m4
@@ -41,6 +41,13 @@ Display brief help text and then exit.
 Request a shutdown followed by restart. This is the default if executed as
 \fB$$$SHUTDOWN_PREFIX@@@reboot\fR.
 .TP
+\fB\-k\fP
+Shutdown the system and boot directly into a new kernel, without firmware
+reinitialisation.
+A suitable kernel image must be loaded first; see \fBkexec\fR(8).
+This is only supported on Linux 2.6.13 or later with \fBCONFIG_KEXEC=y\fR; if
+you're unsure, most distribution kernels qualify.
+.TP
 \fB\-s\fP
 Restart the service manager and all user-space services without restarting the system.
 This is the default if executed as \fB$$$SHUTDOWN_PREFIX@@@soft\-reboot\fR.

--- a/src/control.cc
+++ b/src/control.cc
@@ -75,7 +75,8 @@ bool control_conn_t::process_packet()
             }
 
             if (contains({shutdown_type_t::REMAIN, shutdown_type_t::HALT,
-                    shutdown_type_t::POWEROFF, shutdown_type_t::REBOOT, shutdown_type_t::SOFTREBOOT}, rbuf[1])) {
+                    shutdown_type_t::POWEROFF, shutdown_type_t::REBOOT,
+                    shutdown_type_t::SOFTREBOOT, shutdown_type_t::KEXEC}, rbuf[1])) {
                 auto sd_type = static_cast<shutdown_type_t>(rbuf[1]);
 
                 services->stop_all_services(sd_type);

--- a/src/dinit.cc
+++ b/src/dinit.cc
@@ -700,6 +700,9 @@ int dinit_main(int argc, char **argv)
         else if (shutdown_type == shutdown_type_t::POWEROFF) {
             log_msg_end(" Will power down.");
         }
+        else if (shutdown_type == shutdown_type_t::KEXEC) {
+            log_msg_end(" Will kexec.");
+        }
         else if (shutdown_type == shutdown_type_t::NONE) {
             log_msg_end(" Will handle boot failure.");
         }
@@ -767,6 +770,9 @@ int dinit_main(int argc, char **argv)
         }
         else if (shutdown_type == shutdown_type_t::REBOOT) {
             cmd_arg = "-r";
+        }
+        else if (shutdown_type == shutdown_type_t::KEXEC) {
+            cmd_arg = "-k";
         }
         else {
             // power off.

--- a/src/includes/service-constants.h
+++ b/src/includes/service-constants.h
@@ -36,13 +36,14 @@ enum class service_event_t {
 };
 
 /* Shutdown types */
-enum class shutdown_type_t {
+enum class shutdown_type_t : char {
     NONE,              // No explicit shutdown
     REMAIN,            // Continue running with no services
     HALT,              // Halt system without powering down
     POWEROFF,          // Power off system
     REBOOT,            // Reboot system
-    SOFTREBOOT         // Reboot dinit
+    SOFTREBOOT,        // Reboot dinit
+    KEXEC              // Reboot with kexec (without firmware reinitialisation)
 };
 
 /* Reasons for why service stopped */

--- a/src/shutdown.cc
+++ b/src/shutdown.cc
@@ -246,6 +246,27 @@ class subproc_buffer : private cpbuffer<subproc_bufsize>
     }
 };
 
+static bool reboot_cmd_unsupported(const shutdown_type_t type)
+{
+    // weed out unsupported values
+    switch (type) {
+#if !defined(RB_HALT_SYSTEM) && !defined(RB_HALT)
+    case shutdown_type_t::HALT:
+        return true;
+#endif
+#ifndef RB_POWER_OFF
+    case shutdown_type_t::POWEROFF:
+        return true;
+#endif
+#ifndef RB_KEXEC
+    case shutdown_type_t::KEXEC:
+        return true;
+#endif
+    default:
+        return false;
+    }
+}
+
 
 int main(int argc, char **argv)
 {
@@ -287,6 +308,9 @@ int main(int argc, char **argv)
             else if (strcmp(argv[i], "-s") == 0) {
                 shutdown_type = shutdown_type_t::SOFTREBOOT;
             }
+            else if (strcmp(argv[i], "-k") == 0) {
+                shutdown_type = shutdown_type_t::KEXEC;
+            }
             else if (strcmp(argv[i], "--use-passed-cfd") == 0) {
                 use_passed_cfd = true;
             }
@@ -306,8 +330,15 @@ int main(int argc, char **argv)
                 "  --help           : show this help\n"
                 "  -r               : reboot\n"
                 "  -s               : soft-reboot (restart dinit with same boot-time arguments)\n"
+#if defined(RB_HALT_SYSTEM) || defined(RB_HALT)
                 "  -h               : halt system\n"
+#endif
+#ifdef RB_POWER_OFF
                 "  -p               : power down (default)\n"
+#endif
+#ifdef RB_KEXEC
+                "  -k               : stop dinit and reboot directly into kernel loaded with kexec\n"
+#endif
                 "  --use-passed-cfd : use the socket file descriptor identified by the DINIT_CS_FD\n"
                 "                     environment variable to communicate with the init daemon.\n"
                 "  --system         : perform shutdown immediately, instead of issuing shutdown\n"
@@ -318,7 +349,12 @@ int main(int argc, char **argv)
     
     if (sys_shutdown) {
         do_system_shutdown(shutdown_type);
-        return 0;
+        return 1; // likely to cause panic; the above shouldn't return
+    }
+
+    if (reboot_cmd_unsupported(shutdown_type)) {
+        cerr << "Unsupported shutdown type\n";
+        return 1;
     }
 
     signal(SIGPIPE, SIG_IGN);
@@ -421,6 +457,9 @@ void do_system_shutdown(shutdown_type_t shutdown_type)
 #elif defined(RB_HALT)
     if (shutdown_type == shutdown_type_t::HALT) reboot_type = RB_HALT;
 #endif
+#if defined(RB_KEXEC)
+    if (shutdown_type == shutdown_type_t::KEXEC) reboot_type = RB_KEXEC;
+#endif
     
     // Write to console rather than any terminal, since we lose the terminal it seems:
     int consfd = open("/dev/console", O_WRONLY);
@@ -499,7 +538,18 @@ void do_system_shutdown(shutdown_type_t shutdown_type)
 #ifdef __NetBSD__
     reboot(reboot_type, NULL);
 #else
-    reboot(reboot_type);
+    if (reboot(reboot_type)) {
+        // we're in trouble now
+        sub_buf.append("reboot: ");
+        sub_buf.append(strerror(errno));
+        if (shutdown_type == shutdown_type_t::KEXEC) {
+            sub_buf.append(
+                    "\nIt is possible that no suitable kernel image was loaded before"
+                    "\nreboot with kexec was attempted.\n"
+            );
+        }
+        while (true) loop.run();
+    }
 #endif
 }
 


### PR DESCRIPTION
Adds a -k option to 'shutdown', analogous to that of systemd and OpenRC. Am daily driving this and it gets a nice speedup on reboot. Also tried to make the ifdef-ing out of shutdown code based on RB_* constants more consistent, so the user can clearly see which shutdown modes are supported (since kexec may not be available at compile time on very old environments).

The only real downside that I can see is if the user has neglected to load an image before calling 'reboot -k', then reboot will return -1 with EINVAL, init will exit and the kernel will panic. I can't see an easy way to avoid this, since we only find out that the user *has* remembered to load an image when we call reboot() and it doesn't return.