### PR TITLE
meson: Add missing service arguments related tests

### DIFF
--- a/src/igr-tests/meson.build
+++ b/src/igr-tests/meson.build
@@ -17,7 +17,7 @@ tests = [
     'check-basic', 'check-cycle', 'check-cycle2', 'check-lint', 'reload1', 'reload2',
     'no-command-error', 'add-rm-dep', 'var-subst', 'svc-start-fail', 'dep-not-found',
     'pseudo-cycle', 'before-after', 'before-after2', 'log-via-pipe', 'catlog',
-    'offline-enable', 'xdg-config', 'cycles'
+    'offline-enable', 'xdg-config', 'cycles', 'svc-arg', 'svc-arg-consumer'
 ]
 
 foreach test: tests


### PR DESCRIPTION
Those two were missing.

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`