### PR TITLE
CI: Update freebsd-14-0 to freebsd-14-2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,7 +21,7 @@ Dinit with hardening CI_task:
     TEST_LDFLAGS: # ASLR breaks -fsanitize=address,undefined
 
   freebsd_instance:
-    image_family: freebsd-14-0
+    image_family: freebsd-14-2
 
   Getting depends_script: pkg update && ASSUME_ALWAYS_YES=YES pkg install gmake m4 file llvm15
   Configure_script: ./configure


### PR DESCRIPTION
FreeBSD 14.0-RELEASE is EOF([1]) and also removed from CirrusCI.
This commit fixes recent CI failure.

[1]: https://www.freebsd.org/security/unsupported/

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`