### PR TITLE
meson: Always add trailing slash for IGR_{INPUT/OUTPUT}_BASE paths

### DIFF
--- a/src/igr-tests/meson.build
+++ b/src/igr-tests/meson.build
@@ -1,8 +1,8 @@
 # Included from top-level meson.build
 
 igr_tests_env += [
-    'IGR_OUTPUT_BASE=@0@'.format(meson.current_build_dir()),
-    'IGR_INPUT_BASE=@0@'.format(meson.current_source_dir())
+    'IGR_OUTPUT_BASE=@0@/'.format(meson.current_build_dir()),
+    'IGR_INPUT_BASE=@0@/'.format(meson.current_source_dir())
 ]
 
 runner = executable(


### PR DESCRIPTION
igr-runner expects this way. meson by default add a trailing slash for current source and build directory but there is no guarantee that it does this way. For example muon doesn't add trailing slash for mentioned paths so always add that slash when it's expected.

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`