### PR TITLE
meson: Fix fuzzer build when building with libcap

### DIFF
--- a/src/tests/cptests/meson.build
+++ b/src/tests/cptests/meson.build
@@ -47,6 +47,7 @@ if fuzzer
         include_directories: incdir,
         install: false,
         cpp_args: '-fsanitize=address,undefined,fuzzer-no-link,leak',
-        link_args: '-fsanitize=fuzzer,address,undefined,leak'
+        link_args: '-fsanitize=fuzzer,address,undefined,leak',
+        dependencies: [libcap_dep]
     )
 endif


### PR DESCRIPTION
Similar to #437 but for meson build.

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`