### PR TITLE
igr-runner: Fix inconsistent trailing slash for igr_input_basedir

### DIFF
--- a/src/igr-tests/igr-runner.cc
+++ b/src/igr-tests/igr-runner.cc
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
         igr_output_basedir = env_igr_output_base;
     }
 
-    igr_input_basedir = get_full_cwd() + "/";
+    igr_input_basedir = get_full_cwd();
     char *env_igr_input_basedir = getenv("IGR_INPUT_BASE");
     if (env_igr_input_basedir != nullptr) {
         igr_input_basedir = env_igr_input_basedir;

--- a/src/igr-tests/igr.h
+++ b/src/igr-tests/igr.h
@@ -297,7 +297,7 @@ public:
             args.insert(args.begin(), "--ready-fd");
         }
 
-        igr_proc::start((igr_input_basedir + wdir).c_str(), (dinit_bindir + "/dinit").c_str(), args);
+        igr_proc::start((igr_input_basedir + "/" + wdir).c_str(), (dinit_bindir + "/dinit").c_str(), args);
 
         if (with_ready_wait) {
             while (ready_pipe_ptr->get_output().empty()) {
@@ -316,7 +316,7 @@ public:
 
     void start(const char *wdir, std::vector<std::string> args = {})
     {
-        igr_proc::start((igr_input_basedir + wdir).c_str(), (dinit_bindir + "/dinitctl").c_str(), args);
+        igr_proc::start((igr_input_basedir + "/" + wdir).c_str(), (dinit_bindir + "/dinitctl").c_str(), args);
     }
 };
 
@@ -329,7 +329,7 @@ public:
 
     void start(const char *wdir, std::vector<std::string> args = {})
     {
-        igr_proc::start((igr_input_basedir + wdir).c_str(), (dinit_bindir + "/dinitcheck").c_str(), args,
+        igr_proc::start((igr_input_basedir + "/" + wdir).c_str(), (dinit_bindir + "/dinitcheck").c_str(), args,
                 true /* combine stdout/err */);
     }
 };


### PR DESCRIPTION
Don't add trailing slash to `igr_input_basedir` and not expect tools to provide directories with trailing slash, instead use slash when it's appropriate.

`Signed-off-by: Mobin Aydinfar <mobin@mobintestserver.ir>`