### PR TITLE
CI: Use ubuntu-24.04 for regular ci

### DIFF
--- a/.github/workflows/regular_ci.yml
+++ b/.github/workflows/regular_ci.yml
@@ -33,7 +33,7 @@ jobs:
 
   Debian-bullseye_build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       image: debian:bullseye
     strategy:
@@ -109,7 +109,7 @@ jobs:
 
   Alpine-latest_build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       image: alpine:latest
     strategy:


### PR DESCRIPTION
Ubuntu-20.04 is getting removed from GitHub CI and we need to move to newer version.

I hope there not be ASLR related bugs.

See https://github.com/actions/runner-images/issues/11101 for more details.