### PR TITLE
meson: Use static_library for shared sources

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -1,26 +1,39 @@
 # Included from top-level meson.build
 
 ## Includes
-# We include `../`, `./includes/` & `../dasynq/include/` as defualt_incdir
 default_incdir = include_directories(
     '../',
     'includes/',
     '../dasynq/include/'
 )
-dinit_source_files = [
-    'dinit-main.cc',
-    'dinit.cc',
-    'load-service.cc',
-    'service.cc',
-    'proc-service.cc',
-    'baseproc-service.cc',
-    'control.cc',
-    'dinit-log.cc',
-    'run-child-proc.cc',
+libdinit = static_library(
+    'shared_dinit_objects',
     'options-processing.cc',
     'dinit-env.cc',
-    'settings.cc'
-]
+    'settings.cc',
+    include_directories: default_incdir,
+    install: false
+)
+
+## src/'s defines for tests/ and fuzzer
+if unit_tests or fuzzer
+    for_tests_incdir = include_directories('tests/test-includes/')
+    libtests = static_library(
+        'for_tests_general_objects',
+        'tests/test-dinit.cc',
+        'tests/test-bpsys.cc',
+        'tests/test-run-child-proc.cc',
+        'service.cc',
+        'proc-service.cc',
+        'load-service.cc',
+        'baseproc-service.cc',
+        'dinit-log.cc',
+        'control.cc',
+        link_with: libdinit,
+        include_directories: [ for_tests_incdir, default_incdir ],
+        install: false
+    )
+endif
 
 ## src/'s Defines
 shutdown_built = false
@@ -28,6 +41,7 @@ misc_args = {
     'include_directories': default_incdir,
     'install': true,
     'install_dir': sbindir,
+    'link_with': libdinit,
     'dependencies': [libcap_dep]
 }
 
@@ -40,21 +54,25 @@ endif
 # Standard apps: dinit, dinitctl, dinitcheck, dinit-monitor
 executable(
     'dinit',
-    dinit_source_files,
+    'dinit-main.cc',
+    'dinit.cc',
+    'run-child-proc.cc',
+    'service.cc',
+    'proc-service.cc',
+    'load-service.cc',
+    'baseproc-service.cc',
+    'dinit-log.cc',
+    'control.cc',
     kwargs: misc_args
 )
 executable(
     'dinitctl',
     'dinitctl.cc',
-    'options-processing.cc',
-    'settings.cc',
     kwargs: misc_args
 )
 executable(
     'dinitcheck',
     'dinitcheck.cc',
-    'options-processing.cc',
-    'settings.cc',
     kwargs: misc_args
 )
 executable(

--- a/src/tests/cptests/meson.build
+++ b/src/tests/cptests/meson.build
@@ -1,26 +1,5 @@
 # Included from top-level meson.build
 
-## Includes
-incdir = include_directories(
-    '../../../',
-    '../test-includes/',
-    '../../includes/',
-    '../../../dasynq/include/'
-)
-sources = [
-    '../test-bpsys.cc',
-    '../test-dinit.cc',
-    '../test-run-child-proc.cc',
-    '../../control.cc',
-    '../../dinit-log.cc',
-    '../../service.cc',
-    '../../load-service.cc',
-    '../../proc-service.cc',
-    '../../baseproc-service.cc',
-    '../../dinit-env.cc',
-    '../../settings.cc'
-]
-
 ## dinit with libfuzzer can't be compiled without clang/clang++. For some reasons, Meson don't support set default compiler in default_options.
 if fuzzer and compiler.get_id() != 'clang'
     error('Fuzz target must compiles with clang instead of @0@'.format(compiler.get_id()))
@@ -32,8 +11,8 @@ if unit_tests
     cptests_exec = executable(
         'cptests',
         'cptests.cc',
-        sources,
-        include_directories: incdir,
+        link_with: libtests,
+        include_directories: [ for_tests_incdir, default_incdir ],
         dependencies: [libcap_dep]
     )
     test('cptests', cptests_exec, suite: 'unit_tests')
@@ -43,8 +22,8 @@ if fuzzer
     executable(
         'fuzz',
         'fuzz.cc',
-        sources,
-        include_directories: incdir,
+        link_with: libtests,
+        include_directories: [ for_tests_incdir, default_incdir ],
         install: false,
         cpp_args: '-fsanitize=address,undefined,fuzzer-no-link,leak',
         link_args: '-fsanitize=fuzzer,address,undefined,leak',

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -1,60 +1,51 @@
 # Included from top-level meson.build
 
 ## Includes
-for_tests_incdir = include_directories(
-    '../../',
-    'test-includes/',
-    '../includes/',
-    '../../dasynq/include/'
-)
-for_tests_dinit_sources = [
-    '../service.cc', 
-    '../proc-service.cc',
-    '../dinit-log.cc',
-    '../load-service.cc',
-    '../baseproc-service.cc',
-    '../dinit-env.cc',
-    '../control.cc',
-    '../settings.cc'
-]
-for_tests_general_sources = [
+for_tests_incdir = include_directories('test-includes/')
+libtests = static_library(
+    'for_tests_general_objects',
     'test-dinit.cc',
     'test-bpsys.cc',
-    'test-run-child-proc.cc'
-]
+    'test-run-child-proc.cc',
+    '../service.cc',
+    '../proc-service.cc',
+    '../load-service.cc',
+    '../baseproc-service.cc',
+    '../dinit-log.cc',
+    '../control.cc',
+    link_with: libdinit,
+    include_directories: [ for_tests_incdir, default_incdir ],
+    install: false
+)
 
 ## Outputs
 # Unit tests
 tests_exec = executable(
     'tests',
     'tests.cc',
-    for_tests_general_sources,
-    for_tests_dinit_sources,
-    include_directories: for_tests_incdir,
+    link_with: libtests,
+    include_directories: [ for_tests_incdir, default_incdir ],
     dependencies: [libcap_dep]
 )
 proctests_exec = executable(
     'proctests',
     'proctests.cc',
-    for_tests_general_sources,
-    for_tests_dinit_sources,
-    include_directories: for_tests_incdir,
+    link_with: libtests,
+    include_directories: [ for_tests_incdir, default_incdir ],
     dependencies: [libcap_dep]
 )
 loadtests_exec = executable(
     'loadtests',
     'loadtests.cc',
-    for_tests_general_sources,
-    for_tests_dinit_sources,
-    include_directories: for_tests_incdir,
+    link_with: libtests,
+    include_directories: [ for_tests_incdir, default_incdir ],
     dependencies: [libcap_dep]
 )
 envtests_exec = executable(
     'envtests',
     'envtests.cc',
-    for_tests_general_sources,
-    for_tests_dinit_sources, 
-    include_directories: for_tests_incdir,
+    link_with: libtests,
+    include_directories: [ for_tests_incdir, default_incdir ],
     dependencies: [libcap_dep]
 )
 test('tests', tests_exec, suite: 'unit_tests')


### PR DESCRIPTION
In Make-based builds tests are build twice with all sources because of different flags for tests. In meson this is not the case so just link to shared source instead of rebuiling over and over. Also this fixes building every test source for every single test target.

This reduces ninja targets count from 98 to just 60.