### PR TITLE
CI: run the workflows on configure changes

### DIFF
--- a/.github/workflows/regular_ci.yml
+++ b/.github/workflows/regular_ci.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - '.github/workflows/regular_ci.yml'
+      - 'configure'
       - 'build/**'
       - 'configs/**'
       - 'dasynq/**'
@@ -19,6 +20,7 @@ on:
       - master
     paths:
       - '.github/workflows/regular_ci.yml'
+      - 'configure'
       - 'build/**'
       - 'configs/**'
       - 'dasynq/**'


### PR DESCRIPTION
Since https://github.com/davmac314/dinit/commit/be6c06139ea553743e6eade1313dbe364f1d869c Linux builds use configure by default.

Spotted after #489 not checked by CI.