### PR TITLE
configure: fix unbound variable when specifying 'TEST_LDFLAGS_BASE'

### DIFF
--- a/configure
+++ b/configure
@@ -452,7 +452,7 @@ if [ -z "${TEST_LDFLAGS_BASE+IS_SET}" ]; then
     TEST_LDFLAGS_BASE=""
     AUTO_TEST_LDFLAGS_BASE="true"
 else
-    AUTO_TEST_LDFLAGS=BASE="false"
+    AUTO_TEST_LDFLAGS_BASE="false"
 fi
 if [ -z "${LDFLAGS_LIBCAP+IS_SET}" ]; then
     LDFLAGS_LIBCAP=""


### PR DESCRIPTION
The configure sets AUTO_TEST_LDFLAGS_BASE based on whether the user sets TEST_LDFLAGS_BASE or not.
    
There was a typographical error in the AUTO_TEST_LDFLAGS_BASE declaration that would result in an "unbound variable" error later on when TEST_LDFLAGS_BASE is set by the user.

