### PR TITLE
Add dinit-edit, a simple tool that lists and edits service files

### DIFF
--- a/contrib/dinit-edit/COPYING
+++ b/contrib/dinit-edit/COPYING
@@ -1,0 +1,13 @@
+        DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE 
+                    Version 2, December 2004 
+
+ Copyright (C) 2004 Sam Hocevar <sam@hocevar.net> 
+
+ Everyone is permitted to copy and distribute verbatim or modified 
+ copies of this license document, and changing it is allowed as long 
+ as the name is changed. 
+
+            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE 
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION 
+
+  0. You just DO WHAT THE FUCK YOU WANT TO.

--- a/contrib/dinit-edit/README
+++ b/contrib/dinit-edit/README
@@ -1,0 +1,28 @@
+`dinit-edit` -- list all dinit service files or edit one
+
+## Usage
+
+```
+# list all
+dinit-edit
+
+# edit one
+dinit-edit <service>
+```
+
+Note: Please don't have space or other weird characters inside the service file path, since it's passed to `sh -c '$EDITOR $service_file_path'`.
+
+## Building
+
+There are two equivalent implementations, 1 in Go, 1 in Zig.
+
+## Buliding The Go implementation
+
+```
+ninja
+```
+
+## Building The Zig implementatinon
+
+See build.ninja. You must use Zig 0.14.1.
+

--- a/contrib/dinit-edit/build.ninja
+++ b/contrib/dinit-edit/build.ninja
@@ -1,0 +1,8 @@
+rule zig
+    command = zig build-exe -O ReleaseSafe $in
+
+rule go
+    command = go build $in
+
+#build dinit-edit: zig dinit-edit.zig
+build dinit-edit: go dinit-edit.go

--- a/contrib/dinit-edit/dinit-edit.go
+++ b/contrib/dinit-edit/dinit-edit.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"slices"
+	"syscall"
+)
+
+func getServiceDirs() (serviceDirs []string) {
+	if os.Getuid() == 0 {
+		serviceDirs = []string{"/etc/dinit.d", "/run/dinit.d", "/usr/local/lib/dinit.d", "/lib/dinit.d"}
+	} else {
+		if xdg_home, ok := os.LookupEnv("XDG_CONFIG_HOME"); ok {
+			serviceDirs = append(serviceDirs, path.Join(xdg_home, "dinit.d"))
+		}
+		if home, ok := os.LookupEnv("HOME"); ok {
+			serviceDirs = append(serviceDirs, path.Join(home, ".config/dinit.d"))
+		}
+		serviceDirs = slices.Concat(serviceDirs, []string{"/etc/dinit.d/user", "/usr/lib/dinit.d/user", "/usr/local/lib/dinit.d/user"})
+	}
+	return
+}
+
+type Service struct {
+	Name string
+	Path string
+}
+
+func main() {
+	dirs := getServiceDirs()
+	services := []Service{}
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			// missing dir is ok
+			if !os.IsNotExist(err) {
+				fmt.Println(err)
+			}
+		} else {
+			for _, entry := range entries {
+				if entry.Type().IsRegular() {
+					name := entry.Name()
+					path := path.Join(dir, name)
+					services = append(services, Service{
+						Name: name,
+						Path: path,
+					})
+				}
+			}
+		}
+	}
+
+	if len(os.Args) < 2 {
+		listAll(services)
+	} else {
+		edit(services, os.Args[1])
+	}
+}
+
+func listAll(services []Service) {
+	longest := 0
+	for _, srv := range services {
+		longest = max(longest, len(srv.Name))
+	}
+	for _, srv := range services {
+		fmt.Fprintf(os.Stdout, "%-*s%s\n", longest+4, srv.Name, srv.Path)
+	}
+}
+
+func edit(services []Service, name string) {
+	i := slices.IndexFunc(services, func(srv Service) bool { return srv.Name == name })
+	if i < 0 {
+		fmt.Println("service not found:", name)
+		os.Exit(1)
+	} else {
+		if editor_sh, ok := os.LookupEnv("EDITOR"); ok {
+			err := syscall.Exec("/bin/sh", []string{"sh", "-c", editor_sh + " " + services[i].Path}, os.Environ())
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+		}
+	}
+}

--- a/contrib/dinit-edit/dinit-edit.zig
+++ b/contrib/dinit-edit/dinit-edit.zig
@@ -1,0 +1,74 @@
+const std = @import("std");
+
+const a = std.heap.smp_allocator;
+
+var service_dirs: std.ArrayListUnmanaged([:0]const u8) = .empty;
+
+var services: std.StringArrayHashMapUnmanaged([:0]const u8) = .empty;
+
+pub fn main() !void {
+    try load_definitions();
+
+    if (std.os.argv.len == 1) try list_all();
+    if (std.os.argv.len == 2) try edit(std.mem.span(std.os.argv[1]));
+}
+
+pub fn load_definitions() !void {
+    const uid = std.posix.system.getuid();
+
+    if (uid == 0) {
+        var default_system = [_][:0]const u8{ "/etc/dinit.d", "/run/dinit.d", "/usr/local/lib/dinit.d", "/lib/dinit.d" };
+        service_dirs = .fromOwnedSlice(&default_system);
+    } else {
+        service_dirs = try .initCapacity(a, 5);
+        if (std.posix.getenv("XDG_CONFIG_HOME")) |prefix| {
+            service_dirs.appendAssumeCapacity(try std.fmt.allocPrintZ(a, "{s}/dinit.d", .{prefix}));
+        }
+        if (std.posix.getenv("HOME")) |prefix| {
+            service_dirs.appendAssumeCapacity(try std.fmt.allocPrintZ(a, "{s}/.config/dinit.d", .{prefix}));
+        }
+        service_dirs.appendSliceAssumeCapacity(&.{ "/etc/dinit.d/user", "/usr/lib/dinit.d/user", "/usr/local/lib/dinit.d/user" });
+    }
+
+    for (service_dirs.items) |dir_path| {
+        const dir = std.fs.openDirAbsoluteZ(dir_path, .{ .iterate = true }) catch |e| {
+            if (e == error.FileNotFound) continue;
+            return e;
+        };
+        var iter = dir.iterate();
+        while (try iter.next()) |entry| {
+            // std.log.info("{s}/{s}", .{ dir_path, entry.name });
+            if (entry.kind == .file and !services.contains(entry.name)) {
+                try services.put(a, try a.dupe(u8, entry.name), try std.fmt.allocPrintZ(a, "{s}/{s}", .{ dir_path, entry.name }));
+            }
+        }
+    }
+}
+
+fn list_all() !void {
+    const stdout = std.io.getStdOut();
+    var longest: usize = 0;
+    var iter = services.iterator();
+    while (iter.next()) |entry| {
+        longest = @max(longest, entry.key_ptr.len);
+    }
+    const pad_buffer: [36]u8 = @splat(' ');
+    iter = services.iterator();
+    while (iter.next()) |entry| {
+        const pad = pad_buffer[0 .. longest + 4 - entry.key_ptr.len];
+        try stdout.writer().print("{s}{s}{s}\n", .{ entry.key_ptr.*, pad, entry.value_ptr.* });
+    }
+}
+
+fn edit(service_name: []const u8) !void {
+    const editor = std.posix.getenvZ("EDITOR") orelse "/usr/bin/kak";
+    var iter = services.iterator();
+    while (iter.next()) |entry| {
+        if (std.mem.eql(u8, entry.key_ptr.*, service_name)) {
+            const command = try std.fmt.allocPrintZ(a, "{s} {s}", .{ editor, entry.value_ptr.* });
+            return std.posix.execveZ("/bin/sh", &.{ "sh", "-c", command }, @ptrCast(std.os.environ));
+        }
+    }
+    std.debug.print("Cannot find service file\n", .{});
+    std.process.exit(1);
+}


### PR DESCRIPTION
Idea from https://github.com/davmac314/dinit/issues/508#issuecomment-3506476353

Solves:

- "Where are my service files?"
- Quickly edit a existing service file

The set of directories searched comes from dinit's man page.

(see patch) Is this the proper way to add a license file for a subdirectory?