### PR TITLE
CI: Update FreeBSD 14.2 to FreeBSD 14.3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,7 +21,7 @@ Dinit with hardening CI_task:
     TEST_LDFLAGS: # ASLR breaks -fsanitize=address,undefined
 
   freebsd_instance:
-    image_family: freebsd-14-2
+    image_family: freebsd-14-3
 
   Getting depends_script: pkg update && ASSUME_ALWAYS_YES=YES pkg install gmake m4 file llvm15
   Configure_script: ./configure


### PR DESCRIPTION
The support for FreeBSD 14.2-RELEASE ended on September 30, 2025, and Cirrus CI has removed its 14.2 instance.

See https://www.freebsd.org/security/unsupported/ for unsupported releases information.

This fixes the recent failure of FreeBSD CI in commit 0e6a14f.
