### PR TITLE
configure: improve cross-compilation detection

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -168,8 +168,16 @@ Consult compiler documentation for further information on the above options.
 Cross-compilation with "configure" script
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
-If cross-compiling (i.e. specifying the CXX_FOR_BUILD variable), there are some additional
-considerations regarding use of the "configure" script.
+If the CXX_FOR_BUILD variable is specified, the "configure" script will assume the build is a
+cross-build, unless all of the following conditions are met:
+
+* Both the host compiler (CXX variable) and the build compiler (CXX_FOR_BUILD variable) are the
+same.
+* Their respective compiler flags (CXXFLAGS and CXXFLAGS_FOR_BUILD variables) are the same or both
+unset.
+* The CXXFLAGS_EXTRA variable is unset.
+
+If all of these conditions are met, the "configure" script will instead assume the build is native.
 
 Some build options are currently defaulted based on the detected platform (operating system). When
 doing a cross-build, the target platform is not automatically detected, and "configure" prints a

--- a/configure
+++ b/configure
@@ -450,6 +450,21 @@ for arg in "$@"; do
     esac
 done
 
+## Verify the build is a cross-build when CXX_FOR_BUILD is specified
+if [ -n "${CXX_FOR_BUILD:-}" ]; then
+    # The $CXX_FOR_BUILD is a variable set by the user to the compiler for the build machine.
+    # Later parts of this script assume the build is a cross-build when the $CXX_FOR_BUILD is set.
+    # The following check ensures that either the host compiler and the build compiler and their
+    # respective compiler flags are actually different or that $CXX_FOR_BUILD is unset.
+    if [ "$CXX_FOR_BUILD" = "$CXX" ]; then
+        if [ -z "${CXXFLAGS_EXTRA:-}" ]; then
+            if [ "${CXXFLAGS:-}" = "${CXXFLAGS_FOR_BUILD:-}" ]; then
+                unset CXX_FOR_BUILD
+            fi
+        fi
+    fi
+fi
+
 ## Check platform is specified for a cross-build
 if [ -n "${CXX_FOR_BUILD:-}" ]; then
     if [ -z "${PLATFORM:-}" ]; then


### PR DESCRIPTION
Assume the build as native if both $CXX and $CXX_FOR_BUILD have the same value. If the compiler for the host and the build machine are the same, it's a native build. There is a chance that the user may set both $CXX and $CXX_FOR_BUILD to the same compiler. For example, cbuild (Chimera Linux package builder) sets both variables regardless of native or cross build and because we use $CXX_FOR_BUILD for detecting cross build, we should unset that variable in this case.

Also, GNU autotools detects this case and assumes the build as native.