### PR TITLE
Add dinitctl reexec command to re-execute dinit binary

### DIFF
--- a/src/control.cc
+++ b/src/control.cc
@@ -122,6 +122,16 @@ bool control_conn_t::process_packet()
             return process_signal();
         case cp_cmd::QUERYSERVICEDSCDIR:
             return process_query_dsc_dir();
+        case cp_cmd::REEXEC:
+        {
+            // Re-execute dinit binary
+            services->stop_all_services(shutdown_type_t::REEXEC);
+            char reexecAckBuf[] = { (char)cp_rply::ACK };
+            if (!queue_packet(reexecAckBuf, 1)) return false;
+            rbuf.consume(1);
+            chklen = 0;
+            return true;
+        }
         default:
             break;
     }

--- a/src/includes/control-cmds.h
+++ b/src/includes/control-cmds.h
@@ -91,6 +91,9 @@ enum class cp_cmd : dinit_cptypes::cp_cmd_t {
 
     // Start listening to environment events
     LISTENENV = 27,
+
+    // Re-execute dinit binary
+    REEXEC = 28,
 };
 
 // Replies:

--- a/src/includes/service-constants.h
+++ b/src/includes/service-constants.h
@@ -43,7 +43,8 @@ enum class shutdown_type_t : char {
     POWEROFF,          // Power off system
     REBOOT,            // Reboot system
     SOFTREBOOT,        // Reboot dinit
-    KEXEC              // Reboot with kexec (without firmware reinitialisation)
+    KEXEC,             // Reboot with kexec (without firmware reinitialisation)
+    REEXEC             // Re-execute dinit binary
 };
 
 /* Reasons for why service stopped */


### PR DESCRIPTION
## Summary

This adds a new `dinitctl reexec` command that instructs dinit to re-execute itself using its original `argv[0]` and arguments.

- Adds `REEXEC` shutdown type and control protocol command
- Implements `dinitctl reexec` subcommand
- On reexec failure, falls back to reboot

## Use case

When running a system with a read-only `/usr` mounted from a squashfs image, this enables hot-reloading `/usr` with a new squashfs without a full reboot:

1. Stop all services (`dinitctl stop boot`)
2. Mount new squashfs, swap `/usr` mount (lazy unmount old)
3. Re-execute dinit from the new `/usr/bin/dinit` (`dinitctl reexec`)
4. Start services (`dinitctl start boot`)

This is a minimal implementation that does not include state serialization - users should stop services before re-exec.

Similar functionality exists in other init systems:
- systemd: `systemctl daemon-reexec`
- s6: `s6-svscanctl -a`

Closes #526

## Test plan

- [ ] Build and verify compilation succeeds
- [ ] Test `dinitctl reexec` triggers re-execution
- [ ] Verify fallback to reboot on exec failure