### PR TITLE
ci: add FreeBSD and OpenBSD builds via vmactions

### DIFF
--- a/.github/workflows/regular_ci.yml
+++ b/.github/workflows/regular_ci.yml
@@ -144,3 +144,79 @@ jobs:
       with:
           name: igr-tests_output
           path: src/igr-tests/*/output/*
+
+  FreeBSD_build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Upload src/igr-tests/*/output/* files in igr-tests
+      matrix:
+        include:
+          - arch: 'amd64'
+
+    steps:
+    - uses: actions/checkout@v7
+    - name: Build and test in FreeBSD
+      uses: vmactions/freebsd-vm@v1
+      with:
+        usesh: true
+        cache-after-prepare: true
+        prepare: |
+          pkg install -y gmake
+        run: |
+          set -e
+          echo "--- compiler ---"
+          clang++ -dumpmachine
+          clang++ --version
+          echo "--- build ---"
+          gmake
+          echo "--- executable ---"
+          file ./src/dinit
+          echo "--- unit tests ---"
+          gmake check
+          echo "--- integration tests ---"
+          gmake check-igr
+    - name: Upload igr-tests output file(s) on failure
+      uses: actions/upload-artifact@v4.3.2
+      if: failure()
+      with:
+          name: igr-tests_output_freebsd
+          path: src/igr-tests/*/output/*
+
+  OpenBSD_build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Upload src/igr-tests/*/output/* files in igr-tests
+      matrix:
+        include:
+          - arch: 'amd64'
+
+    steps:
+    - uses: actions/checkout@v7
+    - name: Build and test in OpenBSD
+      uses: vmactions/openbsd-vm@v1
+      with:
+        usesh: true
+        cache-after-prepare: true
+        prepare: |
+          pkg_add -I gmake
+        run: |
+          set -e
+          echo "--- compiler ---"
+          clang++ -dumpmachine
+          clang++ --version
+          echo "--- build ---"
+          gmake
+          echo "--- executable ---"
+          file ./src/dinit
+          echo "--- unit tests ---"
+          gmake check
+          echo "--- integration tests ---"
+          gmake check-igr
+    - name: Upload igr-tests output file(s) on failure
+      uses: actions/upload-artifact@v4.3.2
+      if: failure()
+      with:
+          name: igr-tests_output_openbsd
+          path: src/igr-tests/*/output/*


### PR DESCRIPTION
Closes #558

Cirrus CI shut down on 2026-06-01, which is what removed the FreeBSD
coverage. This adds FreeBSD and OpenBSD jobs to `regular_ci.yml` using the
`vmactions` VM actions suggested in #558 -- they boot the guest under
QEMU/KVM on a regular `ubuntu-latest` runner and cache the VM image.

Both platforms already carry their own build config
(`configs/mconfig.FreeBSD`, `configs/mconfig.OpenBSD`) and the build picks
them up automatically, which the logs confirm:

```
*** Found configuration for OS: FreeBSD
*** Found configuration for OS: OpenBSD
```

NetBSD is left out deliberately: there is no `configs/mconfig.NetBSD`, so it
is not among the directly-supported platforms listed in BUILD.

## Verification

All six jobs green, the existing jobs unaffected:
https://github.com/neilpang/dinit/actions/runs/30680903099

| job | compiler / target | unit tests | integration tests | time |
|-----|-------------------|------------|-------------------|------|
| FreeBSD | clang 19.1.7, `x86_64-unknown-freebsd15.1` | pass (asan+ubsan) | `Passed: 30, Failed: 0` | 4m30s |
| OpenBSD | clang 19.1.7, `amd64-unknown-openbsd7.9` | pass | `Passed: 30, Failed: 0` | 4m10s |

## On the cache limit

You raised the cache limit in #558, so here are the measured numbers:

| cache entry | size |
|-------------|------|
| freebsd base image | 970 MB |
| freebsd image after `prepare` | 1840 MB |
| openbsd base image | 565 MB |
| openbsd image after `prepare` | 779 MB |
| **total** | **~4.15 GB of the 10 GB quota** |

That total includes `cache-after-prepare: true`, which re-caches the image
after `pkg install gmake` so later runs skip the package install entirely.
Dropping that option removes the two "after prepare" entries (~2.6 GB,
leaving ~1.5 GB) at the cost of reinstalling gmake on every run -- a few
seconds. Happy to switch it off if you prefer the smaller footprint.
