### PR TITLE
configure: write empty-but-set XXX_FOR_BUILD flags to mconfig

### DIFF
--- a/configure
+++ b/configure
@@ -822,13 +822,13 @@ if [ -n "${CXX_FOR_BUILD:-}" ]; then
         echo "CXX_FOR_BUILD=$CXX_FOR_BUILD"
     } >> mconfig
 fi
-if [ -n "${CXXFLAGS_FOR_BUILD:-}" ]; then
+if [ -n "${CXXFLAGS_FOR_BUILD+IS_SET}" ]; then
     echo "CXXFLAGS_FOR_BUILD=$CXXFLAGS_FOR_BUILD" >> mconfig
 fi
-if [ -n "${CPPFLAGS_FOR_BUILD:-}" ]; then
+if [ -n "${CPPFLAGS_FOR_BUILD+IS_SET}" ]; then
     echo "CPPFLAGS_FOR_BUILD=$CPPFLAGS_FOR_BUILD" >> mconfig
 fi
-if [ -n "${LDFLAGS_FOR_BUILD:-}" ]; then
+if [ -n "${LDFLAGS_FOR_BUILD+IS_SET}" ]; then
     echo "LDFLAGS_FOR_BUILD=$LDFLAGS_FOR_BUILD" >> mconfig
 fi
 sub_info "done."


### PR DESCRIPTION
Always write 'CXXFLAGS_FOR_BUILD', 'CPPFLAGS_FOR_BUILD' and 'LDFLAGS_FOR_BUILD' variables to mconfig if they are set.

Addresses #552

Tested with `./configure CXX="clang++" CXXFLAGS="--target=aarch64-linux-gnu -std=c++11" CXXFLAGS_FOR_BUILD=""`