### PR TITLE
control: add missing return after BADREQ in add/rm dep

### DIFF
--- a/src/control.cc
+++ b/src/control.cc
@@ -932,6 +932,7 @@ bool control_conn_t::add_service_dep(bool do_enable, bool with_status_response)
         char badreqRep[] = { (char)cp_rply::BADREQ };
         if (!queue_packet(badreqRep, 1)) return false;
         bad_conn_close = true;
+        return true;
     }
     dependency_type dep_type = static_cast<dependency_type>(dep_type_int);
 
@@ -1073,6 +1074,7 @@ bool control_conn_t::rm_service_dep(bool with_status_resp)
         char badreqRep[] = { (char)cp_rply::BADREQ };
         if (!queue_packet(badreqRep, 1)) return false;
         bad_conn_close = true;
+        return true;
     }
     dependency_type dep_type = static_cast<dependency_type>(dep_type_int);
 


### PR DESCRIPTION
Firstly, I have read and understand the CONTRIBUTING guide in full.

I'm currently building systemd-like nix API on top of dinit.
While implementing a forward-port of `SOFT` dependency type to a current dinit version I had noticed that these return statements are missing.
(I would like to discuss bringing `SOFT` dependencies back in a discussion thread later).

If a request with an unknown dependency type is issued, the dinit will respond with BADREQ+ACK and add the invalid dependency to the service's dependency list (which I think is a bug that should be fixed).

