### PR TITLE
Restore the signal mask before soft reboot

### DIFF
--- a/src/dinit.cc
+++ b/src/dinit.cc
@@ -909,9 +909,19 @@ static void do_soft_reboot(char **argv) noexcept
         }
     }
 
+    // Preserve the startup mask across exec, rather than passing our internal
+    // blocked mask to the new instance and the services it starts.
+    sigset_t saved_signal_mask;
+    if (sigprocmask(SIG_SETMASK, &orig_signal_mask, &saved_signal_mask) == -1) {
+        log(loglevel_t::ERROR, "Could not restore signal mask for soft reboot: ", strerror(errno));
+        return;
+    }
+
     // Re-exec the dinit process.
     execv(dinit_exec, argv);
-    log(loglevel_t::ERROR, error_exec_dinit, strerror(errno));
+    int exec_errno = errno;
+    sigprocmask(SIG_SETMASK, &saved_signal_mask, nullptr);
+    log(loglevel_t::ERROR, error_exec_dinit, strerror(exec_errno));
 }
 
 // Callback for control socket


### PR DESCRIPTION
Soft reboot leaves signals blocked in services. On Ironforge, this stopped seatd from handling SIGUSR1 and SIGUSR2, which broke VT switching.

Dinit blocks signals for its own event loop. When it re-executes itself, the new instance saves that blocked mask as `orig_signal_mask` and passes it to services.

Restore the startup mask before `execv`. If `execv` fails, restore the internal mask and keep the error for logging. The shutdown hook still runs with the same mask as before.

Tested on Linux:

- `make check` and `make check-igr` passed (30 integration tests).
- Ran dinit as PID 1 in a separate user/PID namespace and chroot, with a harmless replacement shutdown helper. Unpatched 0.22.1 left SIGUSR1 and SIGUSR2 blocked after soft reboot. Patched 0.22.1 and patched master handled both signals through three soft reboots. SIGWINCH, deliberately blocked at startup, stayed blocked.
- Removed the test instance's dinit executable before soft reboot. The fallback restored the internal mask and logged the original ENOENT error.

Prepared with OpenAI Codex at hholst80's request. The contribution guide generally excludes AI-produced code, so this PR is a draft with that assistance disclosed.
